### PR TITLE
[codegen] add line breaks between code blocks

### DIFF
--- a/generator/src/lib.rs
+++ b/generator/src/lib.rs
@@ -6,6 +6,8 @@ pub mod inject_graphql;
 pub mod sea_orm_codegen;
 pub mod writer;
 
+mod util;
+
 /**
  * Most code depends from here
  * https://github.com/SeaQL/sea-orm/blob/master/sea-orm-cli/src/commands.rs

--- a/generator/src/sea_orm_codegen.rs
+++ b/generator/src/sea_orm_codegen.rs
@@ -1,3 +1,5 @@
+use crate::util::add_line_break;
+
 pub type EntityHashMap = std::collections::HashMap<String, proc_macro2::TokenStream>;
 
 pub fn generate_entities(
@@ -36,7 +38,7 @@ pub fn write_entities<P: AsRef<std::path::Path>>(
 ) -> crate::Result<()> {
     for (name, content) in entities_hashmap.iter() {
         let file_path = path.as_ref().join(name);
-        std::fs::write(file_path, content.to_string().as_bytes())?;
+        std::fs::write(file_path, add_line_break(content.clone()))?;
     }
 
     Ok(())

--- a/generator/src/util.rs
+++ b/generator/src/util.rs
@@ -1,0 +1,38 @@
+use quote::ToTokens;
+
+pub(crate) fn add_line_break(content: proc_macro2::TokenStream) -> String {
+    let file_parsed: syn::File = syn::parse2(content).unwrap();
+    let blocks: Vec<String> =
+        file_parsed
+            .items
+            .iter()
+            .enumerate()
+            .fold(Vec::new(), |mut acc, (i, item)| {
+                let mut s = item.into_token_stream().to_string();
+                if !acc.is_empty() && no_line_break_in_between(&file_parsed.items[i - 1], item) {
+                    let last = acc.swap_remove(acc.len() - 1);
+                    s = format!("{}{}", last, s);
+                }
+                acc.push(s);
+                acc
+            });
+    replace_fully_qualified_spaces(blocks.join("\n\n"))
+}
+
+pub(crate) fn no_line_break_in_between(this: &syn::Item, that: &syn::Item) -> bool {
+    match (this, that) {
+        (syn::Item::Mod(_), syn::Item::Mod(_)) | (syn::Item::Use(_), syn::Item::Use(_)) => true,
+        _ => false,
+    }
+}
+
+pub(crate) fn replace_fully_qualified_spaces(mut str: String) -> String {
+    let targets = [
+        ("seaography :: macros :: ", "seaography::macros::"),
+        ("async_graphql :: ", "async_graphql::"),
+    ];
+    for (from, to) in targets {
+        str = str.replace(from, to);
+    }
+    str
+}

--- a/generator/src/writer.rs
+++ b/generator/src/writer.rs
@@ -2,6 +2,8 @@ use proc_macro2::TokenStream;
 use quote::quote;
 use seaography_discoverer::SqlVersion;
 
+use crate::util::add_line_break;
+
 pub fn generate_query_root(
     entities_hashmap: &crate::sea_orm_codegen::EntityHashMap,
 ) -> Result<TokenStream, crate::error::Error> {
@@ -34,7 +36,7 @@ pub fn write_query_root<P: AsRef<std::path::Path>>(
 
     let file_name = path.as_ref().join("query_root.rs");
 
-    std::fs::write(file_name, tokens.to_string())?;
+    std::fs::write(file_name, add_line_break(tokens))?;
 
     Ok(())
 }
@@ -87,7 +89,7 @@ pub fn write_lib<P: AsRef<std::path::Path>>(path: &P) -> std::io::Result<()> {
 
     let file_name = path.as_ref().join("lib.rs");
 
-    std::fs::write(file_name, tokens.to_string())?;
+    std::fs::write(file_name, add_line_break(tokens))?;
 
     Ok(())
 }
@@ -181,7 +183,7 @@ pub fn write_main<P: AsRef<std::path::Path>>(
 
     let file_name = path.as_ref().join("main.rs");
 
-    std::fs::write(file_name, tokens.to_string())?;
+    std::fs::write(file_name, add_line_break(tokens))?;
 
     Ok(())
 }
@@ -195,15 +197,16 @@ pub fn write_env<P: AsRef<std::path::Path>>(
     let depth_limit = depth_limit.map_or("".into(), |value| value.to_string());
     let complexity_limit = complexity_limit.map_or("".into(), |value| value.to_string());
 
-    let tokens = format!(r#"
-    DATABASE_URL="{db_url}"
-    # COMPLEXITY_LIMIT={depth_limit}
-    # DEPTH_LIMIT={complexity_limit}
-    "#);
+    let tokens = [
+        format!(r#"DATABASE_URL="{}""#, db_url),
+        format!(r#"# COMPLEXITY_LIMIT={}"#, depth_limit),
+        format!(r#"# DEPTH_LIMIT={}"#, complexity_limit),
+    ]
+    .join("\n");
 
     let file_name = path.as_ref().join(".env");
 
-    std::fs::write(file_name, tokens.to_string())?;
+    std::fs::write(file_name, tokens)?;
 
     Ok(())
 }


### PR DESCRIPTION
The resulting entity file will become:

```rs
use sea_orm::entity::prelude::*;

#[derive(
    Clone,
    Debug,
    PartialEq,
    DeriveEntityModel,
    async_graphql::SimpleObject,
    seaography::macros::Filter,
)]
#[sea_orm(table_name = "address")]
#[graphql(complex)]
#[graphql(name = "Address")]
pub struct Model {
    #[sea_orm(primary_key)]
    pub address_id: u16,
    pub address: String,
    pub address2: Option<String>,
    pub district: String,
    pub city_id: u16,
    pub postal_code: Option<String>,
    pub phone: String,
    #[sea_orm(column_type = "Custom(\"GEOMETRY\".to_owned())")]
    pub location: String,
    pub last_update: DateTimeUtc,
}

#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation, seaography::macros::RelationsCompact)]
pub enum Relation {
    #[sea_orm(
        belongs_to = "super::city::Entity",
        from = "Column::CityId",
        to = "super::city::Column::CityId",
        on_update = "Cascade",
        on_delete = "Restrict"
    )]
    City,
    #[sea_orm(has_many = "super::customer::Entity")]
    Customer,
    #[sea_orm(has_many = "super::staff::Entity")]
    Staff,
    #[sea_orm(has_many = "super::store::Entity")]
    Store,
}

impl Related<super::city::Entity> for Entity {
    fn to() -> RelationDef {
        Relation::City.def()
    }
}

impl Related<super::customer::Entity> for Entity {
    fn to() -> RelationDef {
        Relation::Customer.def()
    }
}

impl Related<super::staff::Entity> for Entity {
    fn to() -> RelationDef {
        Relation::Staff.def()
    }
}

impl Related<super::store::Entity> for Entity {
    fn to() -> RelationDef {
        Relation::Store.def()
    }
}

impl ActiveModelBehavior for ActiveModel {}
```