### PR TITLE
PostgreSQL parsing "currentSchema" from DB URL

### DIFF
--- a/discoverer/src/postgres.rs
+++ b/discoverer/src/postgres.rs
@@ -5,16 +5,14 @@ use sqlx::PgPool;
 pub async fn explore_postgres(uri: &str) -> Result<TablesHashMap> {
     let connection = PgPool::connect(uri).await?;
 
-    let database = uri
-        .split('/')
-        .last()
-        .ok_or("database not specified in url")?;
+    let db_uri = url::Url::parse(uri).expect("Fail to parse database URL");
 
-    let schema = database.split("currentSchema=").last().unwrap_or("public");
+    let schema = db_uri
+        .query_pairs()
+        .find(|(k, _)| k == "currentSchema")
+        .map_or("public".to_string(), |(_, v)| v.to_string());
 
-    let schema = if schema.is_empty() { "public" } else { schema };
-
-    let schema_discovery = SchemaDiscovery::new(connection, schema);
+    let schema_discovery = SchemaDiscovery::new(connection, &schema);
 
     let schema = schema_discovery.discover().await;
 


### PR DESCRIPTION
## Fixes

- [x] Parsing of PostgreSQL schema name from DB URL: if the given URL is `postgres://root:root@localhost/sakila` the old behaviour will treat `sakila` as the schema name. This is because it assume all URL of PostgreSQL ends with `?currentSchema=public` (that is provided `postgres://root:root@localhost/sakila?currentSchema=public` as the database URL)