### PR TITLE
Refactoring the main function

### DIFF
--- a/examples/mysql/Cargo.toml
+++ b/examples/mysql/Cargo.toml
@@ -16,6 +16,7 @@ seaography = { version = "^0.1", features = [ "with-decimal", "with-chrono" ] }
 tokio = { version = "1.17.0", features = ["macros", "rt-multi-thread"] }
 tracing = { version = "0.1.34" }
 tracing-subscriber = { version = "0.3.11" }
+lazy_static = { version = "1.4.0" }
 
 [dev-dependencies]
 serde_json = { version = '1.0.82' }

--- a/examples/mysql/src/main.rs
+++ b/examples/mysql/src/main.rs
@@ -5,58 +5,66 @@ use async_graphql::{
 };
 use async_graphql_poem::GraphQL;
 use dotenv::dotenv;
+use lazy_static::lazy_static;
 use poem::{get, handler, listener::TcpListener, web::Html, IntoResponse, Route, Server};
 use sea_orm::Database;
 use seaography_mysql_example::*;
 use std::env;
 
+lazy_static! {
+    static ref URL: String = env::var("URL").unwrap_or("0.0.0.0:8000".into());
+    static ref ENDPOINT: String = env::var("ENDPOINT").unwrap_or("/".into());
+    static ref DATABASE_URL: String =
+        env::var("DATABASE_URL").expect("DATABASE_URL environment variable not set");
+    static ref DEPTH_LIMIT: Option<usize> = env::var("DEPTH_LIMIT").map_or(None, |data| Some(
+        data.parse().expect("DEPTH_LIMIT is not a number")
+    ));
+    static ref COMPLEXITY_LIMIT: Option<usize> = env::var("COMPLEXITY_LIMIT")
+        .map_or(None, |data| {
+            Some(data.parse().expect("COMPLEXITY_LIMIT is not a number"))
+        });
+}
+
 #[handler]
 async fn graphql_playground() -> impl IntoResponse {
-    Html(playground_source(GraphQLPlaygroundConfig::new("/")))
+    Html(playground_source(GraphQLPlaygroundConfig::new(&*ENDPOINT)))
 }
 
 #[tokio::main]
 async fn main() {
     dotenv().ok();
-    let db_url = env::var("DATABASE_URL").expect("DATABASE_URL environment variable not set");
-    let depth_limit = env::var("DEPTH_LIMIT")
-        .map(|data| data.parse::<usize>().expect("DEPTH_LIMIT is not a number"))
-        .map_or(None, |data| Some(data));
-    let complexity_limit = env::var("COMPLEXITY_LIMIT")
-        .map(|data| {
-            data.parse::<usize>()
-                .expect("COMPLEXITY_LIMIT is not a number")
-        })
-        .map_or(None, |data| Some(data));
     tracing_subscriber::fmt()
         .with_max_level(tracing::Level::INFO)
         .with_test_writer()
         .init();
-    let database = Database::connect(db_url).await.unwrap();
+
+    let database = Database::connect(&*DATABASE_URL)
+        .await
+        .expect("Fail to initialize database connection");
     let orm_dataloader: DataLoader<OrmDataloader> = DataLoader::new(
         OrmDataloader {
             db: database.clone(),
         },
         tokio::spawn,
     );
-    let schema = Schema::build(QueryRoot, EmptyMutation, EmptySubscription)
+    let mut schema = Schema::build(QueryRoot, EmptyMutation, EmptySubscription)
         .data(database)
         .data(orm_dataloader);
-    let schema = if let Some(depth) = depth_limit {
-        schema.limit_depth(depth)
-    } else {
-        schema
-    };
-    let schema = if let Some(complexity) = complexity_limit {
-        schema.limit_complexity(complexity)
-    } else {
-        schema
-    };
+    if let Some(depth) = *DEPTH_LIMIT {
+        schema = schema.limit_depth(depth);
+    }
+    if let Some(complexity) = *COMPLEXITY_LIMIT {
+        schema = schema.limit_complexity(complexity);
+    }
     let schema = schema.finish();
-    let app = Route::new().at("/", get(graphql_playground).post(GraphQL::new(schema)));
-    println!("Playground: http://localhost:8000");
-    Server::new(TcpListener::bind("0.0.0.0:8000"))
+    let app = Route::new().at(
+        &*ENDPOINT,
+        get(graphql_playground).post(GraphQL::new(schema)),
+    );
+
+    println!("Visit GraphQL Playground at http://{}", *URL);
+    Server::new(TcpListener::bind(&*URL))
         .run(app)
         .await
-        .unwrap();
+        .expect("Fail to start web server");
 }

--- a/examples/postgres/Cargo.toml
+++ b/examples/postgres/Cargo.toml
@@ -16,6 +16,7 @@ seaography = { version = "^0.1", features = [ "with-decimal", "with-chrono" ] }
 tokio = { version = "1.17.0", features = ["macros", "rt-multi-thread"] }
 tracing = { version = "0.1.34" }
 tracing-subscriber = { version = "0.3.11" }
+lazy_static = { version = "1.4.0" }
 
 [dev-dependencies]
 serde_json = { version = '1.0.82' }

--- a/examples/postgres/src/main.rs
+++ b/examples/postgres/src/main.rs
@@ -5,58 +5,66 @@ use async_graphql::{
 };
 use async_graphql_poem::GraphQL;
 use dotenv::dotenv;
+use lazy_static::lazy_static;
 use poem::{get, handler, listener::TcpListener, web::Html, IntoResponse, Route, Server};
 use sea_orm::Database;
 use seaography_postgres_example::*;
 use std::env;
 
+lazy_static! {
+    static ref URL: String = env::var("URL").unwrap_or("0.0.0.0:8000".into());
+    static ref ENDPOINT: String = env::var("ENDPOINT").unwrap_or("/".into());
+    static ref DATABASE_URL: String =
+        env::var("DATABASE_URL").expect("DATABASE_URL environment variable not set");
+    static ref DEPTH_LIMIT: Option<usize> = env::var("DEPTH_LIMIT").map_or(None, |data| Some(
+        data.parse().expect("DEPTH_LIMIT is not a number")
+    ));
+    static ref COMPLEXITY_LIMIT: Option<usize> = env::var("COMPLEXITY_LIMIT")
+        .map_or(None, |data| {
+            Some(data.parse().expect("COMPLEXITY_LIMIT is not a number"))
+        });
+}
+
 #[handler]
 async fn graphql_playground() -> impl IntoResponse {
-    Html(playground_source(GraphQLPlaygroundConfig::new("/")))
+    Html(playground_source(GraphQLPlaygroundConfig::new(&*ENDPOINT)))
 }
 
 #[tokio::main]
 async fn main() {
     dotenv().ok();
-    let db_url = env::var("DATABASE_URL").expect("DATABASE_URL environment variable not set");
-    let depth_limit = env::var("DEPTH_LIMIT")
-        .map(|data| data.parse::<usize>().expect("DEPTH_LIMIT is not a number"))
-        .map_or(None, |data| Some(data));
-    let complexity_limit = env::var("COMPLEXITY_LIMIT")
-        .map(|data| {
-            data.parse::<usize>()
-                .expect("COMPLEXITY_LIMIT is not a number")
-        })
-        .map_or(None, |data| Some(data));
     tracing_subscriber::fmt()
         .with_max_level(tracing::Level::INFO)
         .with_test_writer()
         .init();
-    let database = Database::connect(db_url).await.unwrap();
+
+    let database = Database::connect(&*DATABASE_URL)
+        .await
+        .expect("Fail to initialize database connection");
     let orm_dataloader: DataLoader<OrmDataloader> = DataLoader::new(
         OrmDataloader {
             db: database.clone(),
         },
         tokio::spawn,
     );
-    let schema = Schema::build(QueryRoot, EmptyMutation, EmptySubscription)
+    let mut schema = Schema::build(QueryRoot, EmptyMutation, EmptySubscription)
         .data(database)
         .data(orm_dataloader);
-    let schema = if let Some(depth) = depth_limit {
-        schema.limit_depth(depth)
-    } else {
-        schema
-    };
-    let schema = if let Some(complexity) = complexity_limit {
-        schema.limit_complexity(complexity)
-    } else {
-        schema
-    };
+    if let Some(depth) = *DEPTH_LIMIT {
+        schema = schema.limit_depth(depth);
+    }
+    if let Some(complexity) = *COMPLEXITY_LIMIT {
+        schema = schema.limit_complexity(complexity);
+    }
     let schema = schema.finish();
-    let app = Route::new().at("/", get(graphql_playground).post(GraphQL::new(schema)));
-    println!("Playground: http://localhost:8000");
-    Server::new(TcpListener::bind("0.0.0.0:8000"))
+    let app = Route::new().at(
+        &*ENDPOINT,
+        get(graphql_playground).post(GraphQL::new(schema)),
+    );
+
+    println!("Visit GraphQL Playground at http://{}", *URL);
+    Server::new(TcpListener::bind(&*URL))
         .run(app)
         .await
-        .unwrap();
+        .expect("Fail to start web server");
 }

--- a/examples/sqlite/Cargo.toml
+++ b/examples/sqlite/Cargo.toml
@@ -16,6 +16,7 @@ seaography = { version = "^0.1", features = [ "with-decimal", "with-chrono" ] }
 tokio = { version = "1.17.0", features = ["macros", "rt-multi-thread"] }
 tracing = { version = "0.1.34" }
 tracing-subscriber = { version = "0.3.11" }
+lazy_static = { version = "1.4.0" }
 
 [dev-dependencies]
 serde_json = { version = '1.0.82' }

--- a/examples/sqlite/src/main.rs
+++ b/examples/sqlite/src/main.rs
@@ -5,58 +5,66 @@ use async_graphql::{
 };
 use async_graphql_poem::GraphQL;
 use dotenv::dotenv;
+use lazy_static::lazy_static;
 use poem::{get, handler, listener::TcpListener, web::Html, IntoResponse, Route, Server};
 use sea_orm::Database;
 use seaography_sqlite_example::*;
 use std::env;
 
+lazy_static! {
+    static ref URL: String = env::var("URL").unwrap_or("0.0.0.0:8000".into());
+    static ref ENDPOINT: String = env::var("ENDPOINT").unwrap_or("/".into());
+    static ref DATABASE_URL: String =
+        env::var("DATABASE_URL").expect("DATABASE_URL environment variable not set");
+    static ref DEPTH_LIMIT: Option<usize> = env::var("DEPTH_LIMIT").map_or(None, |data| Some(
+        data.parse().expect("DEPTH_LIMIT is not a number")
+    ));
+    static ref COMPLEXITY_LIMIT: Option<usize> = env::var("COMPLEXITY_LIMIT")
+        .map_or(None, |data| {
+            Some(data.parse().expect("COMPLEXITY_LIMIT is not a number"))
+        });
+}
+
 #[handler]
 async fn graphql_playground() -> impl IntoResponse {
-    Html(playground_source(GraphQLPlaygroundConfig::new("/")))
+    Html(playground_source(GraphQLPlaygroundConfig::new(&*ENDPOINT)))
 }
 
 #[tokio::main]
 async fn main() {
     dotenv().ok();
-    let db_url = env::var("DATABASE_URL").expect("DATABASE_URL environment variable not set");
-    let depth_limit = env::var("DEPTH_LIMIT")
-        .map(|data| data.parse::<usize>().expect("DEPTH_LIMIT is not a number"))
-        .map_or(None, |data| Some(data));
-    let complexity_limit = env::var("COMPLEXITY_LIMIT")
-        .map(|data| {
-            data.parse::<usize>()
-                .expect("COMPLEXITY_LIMIT is not a number")
-        })
-        .map_or(None, |data| Some(data));
     tracing_subscriber::fmt()
         .with_max_level(tracing::Level::INFO)
         .with_test_writer()
         .init();
-    let database = Database::connect(db_url).await.unwrap();
+
+    let database = Database::connect(&*DATABASE_URL)
+        .await
+        .expect("Fail to initialize database connection");
     let orm_dataloader: DataLoader<OrmDataloader> = DataLoader::new(
         OrmDataloader {
             db: database.clone(),
         },
         tokio::spawn,
     );
-    let schema = Schema::build(QueryRoot, EmptyMutation, EmptySubscription)
+    let mut schema = Schema::build(QueryRoot, EmptyMutation, EmptySubscription)
         .data(database)
         .data(orm_dataloader);
-    let schema = if let Some(depth) = depth_limit {
-        schema.limit_depth(depth)
-    } else {
-        schema
-    };
-    let schema = if let Some(complexity) = complexity_limit {
-        schema.limit_complexity(complexity)
-    } else {
-        schema
-    };
+    if let Some(depth) = *DEPTH_LIMIT {
+        schema = schema.limit_depth(depth);
+    }
+    if let Some(complexity) = *COMPLEXITY_LIMIT {
+        schema = schema.limit_complexity(complexity);
+    }
     let schema = schema.finish();
-    let app = Route::new().at("/", get(graphql_playground).post(GraphQL::new(schema)));
-    println!("Playground: http://localhost:8000");
-    Server::new(TcpListener::bind("0.0.0.0:8000"))
+    let app = Route::new().at(
+        &*ENDPOINT,
+        get(graphql_playground).post(GraphQL::new(schema)),
+    );
+
+    println!("Visit GraphQL Playground at http://{}", *URL);
+    Server::new(TcpListener::bind(&*URL))
         .run(app)
         .await
-        .unwrap();
+        .expect("Fail to start web server");
 }

--- a/generator/src/_Cargo.toml
+++ b/generator/src/_Cargo.toml
@@ -16,6 +16,7 @@ seaography = { version = "^0.1", features = [ "with-decimal", "with-chrono" ] }
 tokio = { version = "1.17.0", features = ["macros", "rt-multi-thread"] }
 tracing = { version = "0.1.34" }
 tracing-subscriber = { version = "0.3.11" }
+lazy_static = { version = "1.4.0" }
 
 [dev-dependencies]
 serde_json = { version = '1.0.82' }

--- a/generator/src/writer.rs
+++ b/generator/src/writer.rs
@@ -100,70 +100,69 @@ pub fn generate_main(crate_name: &str) -> TokenStream {
         };
         use async_graphql_poem::GraphQL;
         use dotenv::dotenv;
+        use lazy_static::lazy_static;
         use poem::{get, handler, listener::TcpListener, web::Html, IntoResponse, Route, Server};
         use sea_orm::Database;
+        use #crate_name_token::*;
         use std::env;
 
-        use #crate_name_token::*;
+        lazy_static! {
+            static ref URL: String = env::var("URL").unwrap_or("0.0.0.0:8000".into());
+            static ref ENDPOINT: String = env::var("ENDPOINT").unwrap_or("/".into());
+            static ref DATABASE_URL: String =
+                env::var("DATABASE_URL").expect("DATABASE_URL environment variable not set");
+            static ref DEPTH_LIMIT: Option<usize> = env::var("DEPTH_LIMIT").map_or(None, |data| Some(
+                data.parse().expect("DEPTH_LIMIT is not a number")
+            ));
+            static ref COMPLEXITY_LIMIT: Option<usize> = env::var("COMPLEXITY_LIMIT")
+                .map_or(None, |data| {
+                    Some(data.parse().expect("COMPLEXITY_LIMIT is not a number"))
+                });
+        }
 
         #[handler]
         async fn graphql_playground() -> impl IntoResponse {
-            Html(playground_source(GraphQLPlaygroundConfig::new("/")))
+            Html(playground_source(GraphQLPlaygroundConfig::new(&*ENDPOINT)))
         }
+
         #[tokio::main]
         async fn main() {
             dotenv().ok();
-
-            let db_url = env::var("DATABASE_URL").expect("DATABASE_URL environment variable not set");
-
-            let depth_limit = env::var("DEPTH_LIMIT")
-                .map(|data| data.parse::<usize>().expect("DEPTH_LIMIT is not a number"))
-                .map_or(None, |data| Some(data));
-
-            let complexity_limit = env::var("COMPLEXITY_LIMIT")
-                .map(|data| {
-                    data.parse::<usize>()
-                        .expect("COMPLEXITY_LIMIT is not a number")
-                })
-                .map_or(None, |data| Some(data));
-
             tracing_subscriber::fmt()
                 .with_max_level(tracing::Level::INFO)
                 .with_test_writer()
                 .init();
-            let database = Database::connect(db_url).await.unwrap();
+
+            let database = Database::connect(&*DATABASE_URL)
+                .await
+                .expect("Fail to initialize database connection");
             let orm_dataloader: DataLoader<OrmDataloader> = DataLoader::new(
                 OrmDataloader {
                     db: database.clone(),
                 },
                 tokio::spawn,
             );
-            let schema = Schema::build(QueryRoot, EmptyMutation, EmptySubscription)
+            let mut schema = Schema::build(QueryRoot, EmptyMutation, EmptySubscription)
                 .data(database)
                 .data(orm_dataloader);
-
-            let schema = if let Some(depth) = depth_limit {
-                schema.limit_depth(depth)
-            } else {
-                schema
-            };
-
-            let schema = if let Some(complexity) = complexity_limit {
-                schema.limit_complexity(complexity)
-            } else {
-                schema
-            };
-
+            if let Some(depth) = *DEPTH_LIMIT {
+                schema = schema.limit_depth(depth);
+            }
+            if let Some(complexity) = *COMPLEXITY_LIMIT {
+                schema = schema.limit_complexity(complexity);
+            }
             let schema = schema.finish();
+            let app = Route::new().at(
+                &*ENDPOINT,
+                get(graphql_playground).post(GraphQL::new(schema)),
+            );
 
-            let app = Route::new().at("/", get(graphql_playground).post(GraphQL::new(schema)));
-            println!("Playground: http://localhost:8000");
-            Server::new(TcpListener::bind("0.0.0.0:8000"))
+            println!("Visit GraphQL Playground at http://{}", *URL);
+            Server::new(TcpListener::bind(&*URL))
                 .run(app)
                 .await
-                .unwrap();
+                .expect("Fail to start web server");
         }
-
     }
 }
 


### PR DESCRIPTION
## Adds

- [x] New environment variable for Seaography playground: http://playground.sea-ql.org/seaography. It allows configuration by simply passing environment variable on the fly without touching the source code.

## Changes

- [x] Reactor the main function which initialize all environment variant inside lazy_static block
