### PR TITLE
Conditionally add filter types list with features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,6 @@ sea-orm = { version = "^0.9", default-features = false }
 
 [features]
 default = []
-with-chrono = ["sea-orm/with-chrono", "async-graphql/chrono"]
-with-decimal = ["sea-orm/with-rust_decimal", "async-graphql/decimal"]
-with-uuid = ["sea-orm/with-uuid"]
+with-chrono = ["seaography-derive/with-chrono", "sea-orm/with-chrono", "async-graphql/chrono"]
+with-decimal = ["seaography-derive/with-decimal", "sea-orm/with-rust_decimal", "async-graphql/decimal"]
+with-uuid = ["seaography-derive/with-uuid", "sea-orm/with-uuid"]

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -21,3 +21,9 @@ syn = { version = "1.0.99" }
 proc-macro2 = "1.0.43"
 bae = "0.1.7"
 heck = "0.4.0"
+
+[features]
+default = []
+with-chrono = []
+with-decimal = []
+with-uuid = []

--- a/derive/src/filter.rs
+++ b/derive/src/filter.rs
@@ -62,10 +62,16 @@ pub fn filter_struct(
                 "u64",
                 "f32",
                 "f64",
+                #[cfg(feature = "with-chrono")]
                 "Date",
+                #[cfg(feature = "with-chrono")]
                 "DateTime",
+                #[cfg(feature = "with-chrono")]
                 "DateTimeUtc",
+                #[cfg(feature = "with-decimal")]
                 "Decimal",
+                #[cfg(feature = "with-uuid")]
+                "Uuid",
                 "BinaryVector",
                 "bool",
             ];


### PR DESCRIPTION
## Adds

- `Uuid` support for `Filter` derive macro

## Fixes

- `Filter` no longer includes types in the default filters list when the matching feature flags are not enabled

## Breaking Changes

- In theory, it would break some UI tests... But I don't think it's worth considering those cases

## Changes

- `seaography-derive` now includes 3 new features: `with-chrono`, `with-decimal`, `with-uuid`. Those match the features from the parent crate.
