### PR TITLE
Re-export internal dependency instead of leaking it into user package

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -95,6 +95,8 @@ jobs:
                   args: >
                     --package seaography-cli --
                     sqlite://sakila.db seaography-sqlite-example ./examples/sqlite
+            - name: Depends on local seaography
+              run: sed -i '/^\[dependencies.seaography\]$/a \path = "..\/..\/"' ./examples/sqlite/Cargo.toml
             - name: Integration tests
               working-directory: ./examples/sqlite
               run: cargo test
@@ -145,6 +147,8 @@ jobs:
                   args: >
                     --package seaography-cli --
                     mysql://sea:sea@127.0.0.1/sakila seaography-mysql-example ./examples/mysql
+            - name: Depends on local seaography
+              run: sed -i '/^\[dependencies.seaography\]$/a \path = "..\/..\/"' ./examples/mysql/Cargo.toml
             - name: Integration tests
               working-directory: ./examples/mysql
               run: cargo test
@@ -192,6 +196,8 @@ jobs:
                   args: >
                     --package seaography-cli --
                     postgres://sea:sea@127.0.0.1/sakila?currentSchema=public seaography-postgres-example ./examples/postgres
+            - name: Depends on local seaography
+              run: sed -i '/^\[dependencies.seaography\]$/a \path = "..\/..\/"' ./examples/postgres/Cargo.toml
             - name: Integration tests
               working-directory: ./examples/postgres
               run: cargo test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,8 @@ categories = ["database"]
 async-graphql = { version = "4.0.12", default-features = false }
 seaography-derive = { version = "^0.1", path = "./derive" }
 sea-orm = { version = "^0.9", default-features = false }
+itertools = { version = "0.10.3" }
+heck = { version = "0.4.0" }
 
 [features]
 default = []

--- a/derive/src/filter.rs
+++ b/derive/src/filter.rs
@@ -100,7 +100,7 @@ pub fn filter_struct(
     // let type_name = quote!{
     //     impl async_graphql::TypeName for Filter {
     //         fn type_name() -> ::std::borrow::Cow<'static, str> {
-    //             use heck::ToUpperCamelCase;
+    //             use seaography::heck::ToUpperCamelCase;
 
     //             let filter_name = format!("{}Filter", Entity::default().table_name().to_string().to_upper_camel_case());
 

--- a/derive/src/relation.rs
+++ b/derive/src/relation.rs
@@ -188,7 +188,7 @@ pub fn relation_fn(
     let (return_type, extra_imports, map_method) = if has_many.is_some() {
         (
             quote! { Vec<#target_model> },
-            quote! { use itertools::Itertools; },
+            quote! { use seaography::itertools::Itertools; },
             quote! { .into_group_map() },
         )
     } else if belongs_to.is_some() {
@@ -270,7 +270,7 @@ pub fn relation_fn(
                     &self,
                     keys: &[#foreign_key_name],
                 ) -> Result<std::collections::HashMap<#foreign_key_name, Self::Value>, Self::Error> {
-                    use heck::ToSnakeCase;
+                    use seaography::heck::ToSnakeCase;
                     use ::std::str::FromStr;
 
                     let key_values: Vec<_> = keys
@@ -313,7 +313,7 @@ pub fn relation_fn(
                 &self,
                 ctx: &async_graphql::Context<'a>,
             ) -> Option<#return_type> {
-                use heck::ToSnakeCase;
+                use seaography::heck::ToSnakeCase;
                 use ::std::str::FromStr;
 
                 let data_loader = ctx

--- a/examples/mysql/Cargo.toml
+++ b/examples/mysql/Cargo.toml
@@ -8,14 +8,16 @@ async-graphql = { version = "4.0.10", features = ["decimal", "chrono", "dataload
 async-graphql-poem = { version = "4.0.10" }
 async-trait = { version = "0.1.53" }
 dotenv = "0.15.0"
-heck = { version = "0.4.0" }
-itertools = { version = "0.10.3" }
 poem = { version = "1.3.29" }
 sea-orm = { version = "^0.9", features = ["sqlx-mysql", "runtime-async-std-native-tls"] }
-seaography = { version = "^0.1", features = [ "with-decimal", "with-chrono" ] }
 tokio = { version = "1.17.0", features = ["macros", "rt-multi-thread"] }
 tracing = { version = "0.1.34" }
 tracing-subscriber = { version = "0.3.11" }
+
+[dependencies.seaography]
+path = "../../" # remove this line in your own project
+version = "^0.1" # seaography version
+features = ["with-decimal", "with-chrono"]
 
 [dev-dependencies]
 serde_json = { version = '1.0.82' }

--- a/examples/postgres/Cargo.toml
+++ b/examples/postgres/Cargo.toml
@@ -8,14 +8,16 @@ async-graphql = { version = "4.0.10", features = ["decimal", "chrono", "dataload
 async-graphql-poem = { version = "4.0.10" }
 async-trait = { version = "0.1.53" }
 dotenv = "0.15.0"
-heck = { version = "0.4.0" }
-itertools = { version = "0.10.3" }
 poem = { version = "1.3.29" }
 sea-orm = { version = "^0.9", features = ["sqlx-postgres", "runtime-async-std-native-tls"] }
-seaography = { version = "^0.1", features = [ "with-decimal", "with-chrono" ] }
 tokio = { version = "1.17.0", features = ["macros", "rt-multi-thread"] }
 tracing = { version = "0.1.34" }
 tracing-subscriber = { version = "0.3.11" }
+
+[dependencies.seaography]
+path = "../../" # remove this line in your own project
+version = "^0.1" # seaography version
+features = ["with-decimal", "with-chrono"]
 
 [dev-dependencies]
 serde_json = { version = '1.0.82' }

--- a/examples/sqlite/Cargo.toml
+++ b/examples/sqlite/Cargo.toml
@@ -8,14 +8,16 @@ async-graphql = { version = "4.0.10", features = ["decimal", "chrono", "dataload
 async-graphql-poem = { version = "4.0.10" }
 async-trait = { version = "0.1.53" }
 dotenv = "0.15.0"
-heck = { version = "0.4.0" }
-itertools = { version = "0.10.3" }
 poem = { version = "1.3.29" }
 sea-orm = { version = "^0.9", features = ["sqlx-sqlite", "runtime-async-std-native-tls"] }
-seaography = { version = "^0.1", features = [ "with-decimal", "with-chrono" ] }
 tokio = { version = "1.17.0", features = ["macros", "rt-multi-thread"] }
 tracing = { version = "0.1.34" }
 tracing-subscriber = { version = "0.3.11" }
+
+[dependencies.seaography]
+path = "../../" # remove this line in your own project
+version = "^0.1" # seaography version
+features = ["with-decimal", "with-chrono"]
 
 [dev-dependencies]
 serde_json = { version = '1.0.82' }

--- a/generator/src/_Cargo.toml
+++ b/generator/src/_Cargo.toml
@@ -10,10 +10,13 @@ async-trait = { version = "0.1.53" }
 dotenv = "0.15.0"
 poem = { version = "1.3.29" }
 sea-orm = { version = "^0.9", features = ["<seaography-sql-library>", "runtime-async-std-native-tls"] }
-seaography = { version = "^0.1", features = [ "with-decimal", "with-chrono" ] }
 tokio = { version = "1.17.0", features = ["macros", "rt-multi-thread"] }
 tracing = { version = "0.1.34" }
 tracing-subscriber = { version = "0.3.11" }
+
+[dependencies.seaography]
+version = "<seaography-version>" # seaography version
+features = ["with-decimal", "with-chrono"]
 
 [dev-dependencies]
 serde_json = { version = '1.0.82' }

--- a/generator/src/_Cargo.toml
+++ b/generator/src/_Cargo.toml
@@ -8,8 +8,6 @@ async-graphql = { version = "4.0.10", features = ["decimal", "chrono", "dataload
 async-graphql-poem = { version = "4.0.10" }
 async-trait = { version = "0.1.53" }
 dotenv = "0.15.0"
-heck = { version = "0.4.0" }
-itertools = { version = "0.10.3" }
 poem = { version = "1.3.29" }
 sea-orm = { version = "^0.9", features = ["<seaography-sql-library>", "runtime-async-std-native-tls"] }
 seaography = { version = "^0.1", features = [ "with-decimal", "with-chrono" ] }

--- a/generator/src/writer.rs
+++ b/generator/src/writer.rs
@@ -47,11 +47,16 @@ pub fn write_cargo_toml<P: AsRef<std::path::Path>>(
 ) -> std::io::Result<()> {
     let file_path = path.as_ref().join("Cargo.toml");
 
-    let content = include_str!("_Cargo.toml");
+    let ver = format!(
+        "^{}.{}.0",
+        env!("CARGO_PKG_VERSION_MAJOR"),
+        env!("CARGO_PKG_VERSION_MINOR")
+    );
 
-    let content = content.replace("<seaography-package-name>", crate_name);
-
-    let content = content.replace("<seaography-sql-library>", sql_library);
+    let content = include_str!("_Cargo.toml")
+        .replace("<seaography-package-name>", crate_name)
+        .replace("<seaography-sql-library>", sql_library)
+        .replace("<seaography-version>", &ver);
 
     std::fs::write(file_path, content.as_bytes())?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,6 +128,8 @@
 //!
 //! Seaography is a community driven project. We welcome you to participate, contribute and together build for Rust's future.
 
+pub use heck;
+pub use itertools;
 pub use seaography_derive as macros;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, async_graphql::Enum)]


### PR DESCRIPTION
## PR Info

- Closes https://github.com/SeaQL/seaography/issues/66
- Closes https://github.com/SeaQL/seaography/issues/50

## Adds

- [x] `seaography` re-export `heck` and `itertools`. We cannot re-export those dependencies on `seaography-macros` because proc_macros crate can only export proc_macros.
- [x] Write `seaography` version dynamically based on the version of `seaography-generator`

## Changes

- [x] `seaography-generator`: `Cargo.toml` template will not include `heck` and `itertools` as dependencies.
- [x] CI compile generated examples that depends on local `seaography`