### PR TITLE
Add additional filters

### DIFF
--- a/derive/src/filter.rs
+++ b/derive/src/filter.rs
@@ -200,37 +200,9 @@ pub fn order_by_fn(fields: &[IdentTypeTuple]) -> Result<TokenStream, crate::erro
 pub fn recursive_filter_fn(fields: &[IdentTypeTuple]) -> Result<TokenStream, crate::error::Error> {
     let columns_filters: Vec<TokenStream> = fields
         .iter()
-        .map(|(ident, ty)| {
+        .map(|(ident, _)| {
             let column_name = format_ident!("{}", ident.to_string().to_snake_case());
-            let type_literal = ty.to_token_stream().to_string();
-
             let column_enum_name = format_ident!("{}", ident.to_string().to_upper_camel_case());
-
-            let ext = if type_literal == "String" {
-                quote! {
-                    if let Some(contains_value) = #column_name.contains {
-                        condition = condition.add(Column::#column_enum_name.contains(contains_value.as_str()))
-                    }
-
-                    if let Some(starts_with_value) = #column_name.starts_with {
-                        condition = condition.add(Column::#column_enum_name.starts_with(starts_with_value.as_str()))
-                    }
-
-                    if let Some(ends_with_value) = #column_name.ends_with {
-                        condition = condition.add(Column::#column_enum_name.ends_with(ends_with_value.as_str()))
-                    }
-
-                    if let Some(like_value) = #column_name.like {
-                        condition = condition.add(Column::#column_enum_name.like(like_value.as_str()))
-                    }
-
-                    if let Some(not_like_value) = #column_name.not_like {
-                        condition = condition.add(Column::#column_enum_name.not_like(not_like_value.as_str()))
-                    }
-                }
-            } else {
-                TokenStream::new()
-            };
 
             quote! {
                 if let Some(#column_name) = current_filter.#column_name {
@@ -272,7 +244,25 @@ pub fn recursive_filter_fn(fields: &[IdentTypeTuple]) -> Result<TokenStream, cra
                         }
                     }
 
-                    #ext
+                    if let Some(contains_value) = #column_name.contains {
+                        condition = condition.add(Column::#column_enum_name.contains(contains_value.as_str()))
+                    }
+
+                    if let Some(starts_with_value) = #column_name.starts_with {
+                        condition = condition.add(Column::#column_enum_name.starts_with(starts_with_value.as_str()))
+                    }
+
+                    if let Some(ends_with_value) = #column_name.ends_with {
+                        condition = condition.add(Column::#column_enum_name.ends_with(ends_with_value.as_str()))
+                    }
+
+                    if let Some(like_value) = #column_name.like {
+                        condition = condition.add(Column::#column_enum_name.like(like_value.as_str()))
+                    }
+
+                    if let Some(not_like_value) = #column_name.not_like {
+                        condition = condition.add(Column::#column_enum_name.not_like(not_like_value.as_str()))
+                    }
                 }
             }
         })

--- a/derive/src/filter.rs
+++ b/derive/src/filter.rs
@@ -80,12 +80,7 @@ pub fn filter_struct(
                 "bool",
             ];
 
-            println!("filter struct {}: {}", ident, type_literal);
-            let filter_item = if type_literal.as_str() == "String" {
-                quote! {
-                    seaography::StringFilter
-                }
-            } else if default_filters.contains(&type_literal.as_str())
+            if default_filters.contains(&type_literal.as_str())
                 || type_literal.starts_with("Vec")
             {
                 quote! {
@@ -202,6 +197,7 @@ pub fn recursive_filter_fn(fields: &[IdentTypeTuple]) -> Result<TokenStream, cra
         .iter()
         .map(|(ident, _)| {
             let column_name = format_ident!("{}", ident.to_string().to_snake_case());
+
             let column_enum_name = format_ident!("{}", ident.to_string().to_upper_camel_case());
 
             quote! {

--- a/derive/src/filter.rs
+++ b/derive/src/filter.rs
@@ -80,7 +80,7 @@ pub fn filter_struct(
                 "bool",
             ];
 
-            if default_filters.contains(&type_literal.as_str())
+            let filter_item = if default_filters.contains(&type_literal.as_str())
                 || type_literal.starts_with("Vec")
             {
                 quote! {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -144,6 +144,7 @@ pub enum OrderByEnum {
 pub type BinaryVector = Vec<u8>;
 
 #[derive(Debug, Clone, async_graphql::InputObject)]
+#[graphql(concrete(name = "StringFilter", params(String)))]
 #[graphql(concrete(name = "TinyIntegerFilter", params(i8)))]
 #[graphql(concrete(name = "SmallIntegerFilter", params(i16)))]
 #[graphql(concrete(name = "IntegerFilter", params(i32)))]
@@ -200,19 +201,6 @@ pub struct TypeFilter<T: async_graphql::InputType> {
     pub lte: Option<T>,
     pub is_in: Option<Vec<T>>,
     pub is_not_in: Option<Vec<T>>,
-    pub is_null: Option<bool>,
-}
-
-#[derive(Debug, Clone, async_graphql::InputObject)]
-pub struct StringFilter {
-    pub eq: Option<String>,
-    pub ne: Option<String>,
-    pub gt: Option<String>,
-    pub gte: Option<String>,
-    pub lt: Option<String>,
-    pub lte: Option<String>,
-    pub is_in: Option<Vec<String>>,
-    pub is_not_in: Option<Vec<String>>,
     pub is_null: Option<bool>,
     pub contains: Option<String>,
     pub starts_with: Option<String>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -144,7 +144,6 @@ pub enum OrderByEnum {
 pub type BinaryVector = Vec<u8>;
 
 #[derive(Debug, Clone, async_graphql::InputObject)]
-#[graphql(concrete(name = "StringFilter", params(String)))]
 #[graphql(concrete(name = "TinyIntegerFilter", params(i8)))]
 #[graphql(concrete(name = "SmallIntegerFilter", params(i16)))]
 #[graphql(concrete(name = "IntegerFilter", params(i32)))]
@@ -202,6 +201,24 @@ pub struct TypeFilter<T: async_graphql::InputType> {
     pub is_in: Option<Vec<T>>,
     pub is_not_in: Option<Vec<T>>,
     pub is_null: Option<bool>,
+}
+
+#[derive(Debug, Clone, async_graphql::InputObject)]
+pub struct StringFilter {
+    pub eq: Option<String>,
+    pub ne: Option<String>,
+    pub gt: Option<String>,
+    pub gte: Option<String>,
+    pub lt: Option<String>,
+    pub lte: Option<String>,
+    pub is_in: Option<Vec<String>>,
+    pub is_not_in: Option<Vec<String>>,
+    pub is_null: Option<bool>,
+    pub contains: Option<String>,
+    pub starts_with: Option<String>,
+    pub ends_with: Option<String>,
+    pub like: Option<String>,
+    pub not_like: Option<String>,
 }
 
 #[derive(Debug, async_graphql::InputObject)]


### PR DESCRIPTION
Adds more filters. I've allowed them for all types, because sea-orm also allows them on all columns (and they produce valid SQL).
The filters do not actually work on some types, like datetime, but it's still valid SQL.

## PR Info

- Closes #57

## New Features

- [x] Allow more filters on types:
  - `starts_with`
  - `ends_with`
  - `contains`
  - `like`
  - `not_like`
