### PR TITLE
Implement starts_with, ends_with, contains, like, not_like operations on StringFilter and add is_not_null operation

### DIFF
--- a/derive/src/enumeration.rs
+++ b/derive/src/enumeration.rs
@@ -16,6 +16,7 @@ pub fn enum_filter_fn(ident: syn::Ident) -> TokenStream {
             pub is_in: Option<Vec<#ident>>,
             pub is_not_in: Option<Vec<#ident>>,
             pub is_null: Option<bool>,
+            pub is_not_null: Option<bool>
         }
 
         impl seaography::FilterTrait for #name {
@@ -47,6 +48,9 @@ pub fn enum_filter_fn(ident: syn::Ident) -> TokenStream {
             }
             fn is_null(&self) -> Option<bool> {
                 self.is_null
+            }
+            fn is_not_null(&self) -> Option<bool> {
+                self.is_not_null
             }
             fn contains(&self) -> Option<String> {
                 panic!("contains not supported for enumerations")

--- a/derive/src/filter.rs
+++ b/derive/src/filter.rs
@@ -197,12 +197,16 @@ pub fn recursive_filter_fn(fields: &[IdentTypeTuple]) -> Result<TokenStream, cra
                     if let Some(is_null_value) = seaography::FilterTrait::is_null(#column_name) {
                         if is_null_value {
                             condition = condition.add(Column::#column_enum_name.is_null())
+                        } else {
+                            condition = condition.add(Column::#column_enum_name.is_not_null())
                         }
                     }
 
                     if let Some(is_not_null_value) = seaography::FilterTrait::is_not_null(#column_name) {
                         if is_not_null_value {
                             condition = condition.add(Column::#column_enum_name.is_not_null())
+                        } else {
+                            condition = condition.add(Column::#column_enum_name.is_null())
                         }
                     }
 

--- a/derive/src/filter.rs
+++ b/derive/src/filter.rs
@@ -272,22 +272,22 @@ pub fn remove_optional_from_type(ty: syn::Type) -> Result<syn::Type, crate::erro
 
     let ty = match ty {
         syn::Type::Path(type_path)
-        if type_path.qself.is_none() && path_is_option(&type_path.path) =>
-            {
-                let type_params = &type_path.path.segments.first().unwrap().arguments;
-                let generic_arg = match type_params {
-                    syn::PathArguments::AngleBracketed(params) => params.args.first().unwrap(),
-                    _ => {
-                        return Err(crate::error::Error::Internal(
-                            "Cannot parse type brackets".into(),
-                        ))
-                    }
-                };
-                match generic_arg {
-                    syn::GenericArgument::Type(ty) => ty.to_owned(),
-                    _ => return Err(crate::error::Error::Internal("Cannot parse type".into())),
+            if type_path.qself.is_none() && path_is_option(&type_path.path) =>
+        {
+            let type_params = &type_path.path.segments.first().unwrap().arguments;
+            let generic_arg = match type_params {
+                syn::PathArguments::AngleBracketed(params) => params.args.first().unwrap(),
+                _ => {
+                    return Err(crate::error::Error::Internal(
+                        "Cannot parse type brackets".into(),
+                    ))
                 }
+            };
+            match generic_arg {
+                syn::GenericArgument::Type(ty) => ty.to_owned(),
+                _ => return Err(crate::error::Error::Internal("Cannot parse type".into())),
             }
+        }
         _ => ty,
     };
 

--- a/derive/src/filter.rs
+++ b/derive/src/filter.rs
@@ -199,6 +199,32 @@ pub fn recursive_filter_fn(fields: &[IdentTypeTuple]) -> Result<TokenStream, cra
                             condition = condition.add(Column::#column_enum_name.is_null())
                         }
                     }
+
+                    if let Some(is_not_null_value) = seaography::FilterTrait::is_not_null(#column_name) {
+                        if is_not_null_value {
+                            condition = condition.add(Column::#column_enum_name.is_not_null())
+                        }
+                    }
+
+                    if let Some(contains_value) = seaography::FilterTrait::contains(#column_name) {
+                        condition = condition.add(Column::#column_enum_name.contains(contains_value.as_str()))
+                    }
+
+                    if let Some(starts_with_value) = seaography::FilterTrait::starts_with(#column_name) {
+                        condition = condition.add(Column::#column_enum_name.starts_with(starts_with_value.as_str()))
+                    }
+
+                    if let Some(ends_with_value) = seaography::FilterTrait::ends_with(#column_name) {
+                        condition = condition.add(Column::#column_enum_name.ends_with(ends_with_value.as_str()))
+                    }
+
+                    if let Some(like_value) = seaography::FilterTrait::like(#column_name) {
+                        condition = condition.add(Column::#column_enum_name.like(like_value.as_str()))
+                    }
+
+                    if let Some(not_like_value) = seaography::FilterTrait::not_like(#column_name) {
+                        condition = condition.add(Column::#column_enum_name.not_like(not_like_value.as_str()))
+                    }
                 }
             }
         })
@@ -246,22 +272,22 @@ pub fn remove_optional_from_type(ty: syn::Type) -> Result<syn::Type, crate::erro
 
     let ty = match ty {
         syn::Type::Path(type_path)
-            if type_path.qself.is_none() && path_is_option(&type_path.path) =>
-        {
-            let type_params = &type_path.path.segments.first().unwrap().arguments;
-            let generic_arg = match type_params {
-                syn::PathArguments::AngleBracketed(params) => params.args.first().unwrap(),
-                _ => {
-                    return Err(crate::error::Error::Internal(
-                        "Cannot parse type brackets".into(),
-                    ))
+        if type_path.qself.is_none() && path_is_option(&type_path.path) =>
+            {
+                let type_params = &type_path.path.segments.first().unwrap().arguments;
+                let generic_arg = match type_params {
+                    syn::PathArguments::AngleBracketed(params) => params.args.first().unwrap(),
+                    _ => {
+                        return Err(crate::error::Error::Internal(
+                            "Cannot parse type brackets".into(),
+                        ))
+                    }
+                };
+                match generic_arg {
+                    syn::GenericArgument::Type(ty) => ty.to_owned(),
+                    _ => return Err(crate::error::Error::Internal("Cannot parse type".into())),
                 }
-            };
-            match generic_arg {
-                syn::GenericArgument::Type(ty) => ty.to_owned(),
-                _ => return Err(crate::error::Error::Internal("Cannot parse type".into())),
             }
-        }
         _ => ty,
     };
 

--- a/src/type_filter.rs
+++ b/src/type_filter.rs
@@ -12,6 +12,7 @@ pub trait FilterTrait {
     fn is_in(&self) -> Option<Vec<Self::Ty>>;
     fn is_not_in(&self) -> Option<Vec<Self::Ty>>;
     fn is_null(&self) -> Option<bool>;
+    fn is_not_null(&self) -> Option<bool>;
     fn contains(&self) -> Option<String>;
     fn starts_with(&self) -> Option<String>;
     fn ends_with(&self) -> Option<String>;
@@ -84,6 +85,7 @@ where
     pub is_in: Option<Vec<T>>,
     pub is_not_in: Option<Vec<T>>,
     pub is_null: Option<bool>,
+    pub is_not_null: Option<bool>,
 }
 
 impl<T> FilterTrait for TypeFilter<T>
@@ -128,24 +130,28 @@ where
         self.is_null
     }
 
+    fn is_not_null(&self) -> Option<bool> {
+        self.is_not_null
+    }
+
     fn contains(&self) -> Option<String> {
-        panic!("FilterType does not support contains")
+        None
     }
 
     fn starts_with(&self) -> Option<String> {
-        panic!("FilterType does not support starts_with")
+        None
     }
 
     fn ends_with(&self) -> Option<String> {
-        panic!("FilterType does not support ends_with")
+        None
     }
 
     fn like(&self) -> Option<String> {
-        panic!("FilterType does not support like")
+        None
     }
 
     fn not_like(&self) -> Option<String> {
-        panic!("FilterType does not support not_like")
+        None
     }
 }
 
@@ -160,6 +166,7 @@ pub struct StringFilter {
     pub is_in: Option<Vec<String>>,
     pub is_not_in: Option<Vec<String>>,
     pub is_null: Option<bool>,
+    pub is_not_null: Option<bool>,
     pub contains: Option<String>,
     pub starts_with: Option<String>,
     pub ends_with: Option<String>,
@@ -204,6 +211,10 @@ impl FilterTrait for StringFilter {
 
     fn is_null(&self) -> Option<bool> {
         self.is_null
+    }
+
+    fn is_not_null(&self) -> Option<bool> {
+        self.is_not_null
     }
 
     fn contains(&self) -> Option<String> {


### PR DESCRIPTION
Implement starts_with, ends_with, contains, like, not_like operations on StringFilter and add is_not_null operation

<!--

Thank you for contributing to this project!

If you need any help please feel free to contact us on Discord: https://discord.com/invite/uCPdDXzbdv
Or, mention our core members by typing `@GitHub_Handle` on any issue / PR

Add some test cases! It help reviewers to understand the behaviour and prevent it to be broken in the future.

-->

## PR Info

<!-- mention the related issue -->
- Closes https://github.com/SeaQL/seaography/issues/57

<!-- any PR depends on this PR? (if applicable) -->
- Dependents:
  - https://github.com/SeaQL/seaography/pull/92

## New Features

- [x] This pull request implements **starts_with**, **ends_with**, **contains**, **like**, **not_like** operations and also adds **is_not_null**. These operations were in api. But they were not implemented.


## Changes

- Adds is_not_null operation to TypeFilter and StringFilter. So now developers can also use this operation. 
