### PR TITLE
impl create/update/delete mutations

### DIFF
--- a/derive/src/mutation.rs
+++ b/derive/src/mutation.rs
@@ -46,9 +46,6 @@ pub fn mutation_fn(item: syn::DataStruct, attrs_seaorm: SeaOrm) -> Result<TokenS
         })
         .collect();
 
-    dbg!(fields.clone());
-
-
     let name = if let syn::Lit::Str(item) = attrs_seaorm.table_name.as_ref().unwrap() {
         Ok(item.value().parse::<TokenStream>()?)
     } else {
@@ -82,7 +79,7 @@ pub fn create_mutation(name: &TokenStream, fields: &[IdentTypeTuple]) -> TokenSt
 
     let variables: Vec<TokenStream> = fields
         .iter()
-        .filter(|(i, _, skip)| { dbg!(&*i); dbg!(&*skip); !*skip })
+        .filter(|(i, _, skip)| { !*skip })
         .map(|(i, tp, _)| {
             quote! {
                 #i: #tp,
@@ -163,7 +160,7 @@ pub fn update_mutation(name: &TokenStream, fields: &[IdentTypeTuple]) -> TokenSt
 
     let variables: Vec<TokenStream> = fields
         .iter()
-        .filter(|(i, _, skip)| { dbg!(&*i); dbg!(&*skip); !*skip })
+        .filter(|(i, _, skip)| { !*skip })
         .map(|(i, tp, _)| {
             quote! {
                 #i: Option<#tp>,

--- a/derive/src/mutation.rs
+++ b/derive/src/mutation.rs
@@ -79,7 +79,7 @@ pub fn create_mutation(name: &TokenStream, fields: &[IdentTypeTuple]) -> TokenSt
 
     let variables: Vec<TokenStream> = fields
         .iter()
-        .filter(|(i, _, skip)| { !*skip })
+        .filter(|(_, _, skip)| { !*skip })
         .map(|(i, tp, _)| {
             quote! {
                 #i: #tp,
@@ -160,7 +160,7 @@ pub fn update_mutation(name: &TokenStream, fields: &[IdentTypeTuple]) -> TokenSt
 
     let variables: Vec<TokenStream> = fields
         .iter()
-        .filter(|(i, _, skip)| { !*skip })
+        .filter(|(_, _, skip)| { !*skip })
         .map(|(i, tp, _)| {
             quote! {
                 #i: Option<#tp>,

--- a/derive/src/mutation.rs
+++ b/derive/src/mutation.rs
@@ -1,0 +1,218 @@
+use proc_macro2::{Ident, TokenStream, Span};
+use quote::quote;
+
+#[derive(Debug, Eq, PartialEq, bae::FromAttributes, Clone)]
+pub struct Seaography {
+    entity: Option<syn::Lit>,
+    object_config: Option<syn::Expr>,
+    not_mutable: Option<syn::Lit>,
+}
+
+#[derive(Debug, Eq, PartialEq, bae::FromAttributes)]
+pub struct SeaographyMutation {
+    table_name: Option<syn::Lit>,
+    mutation_root: Option<syn::Lit>,
+    skip: Option<syn::Lit>
+}
+
+// copy of filter::SeaOrm to make table_name public
+#[derive(Debug, Eq, PartialEq, bae::FromAttributes)]
+pub struct SeaOrm {
+    table_name: Option<syn::Lit>,
+}
+
+// bool is meant as "skip", so this entry cant be created/updated/deleted
+pub type IdentTypeTuple = (syn::Ident, syn::Type, bool);
+
+pub fn mutation_fn(item: syn::DataStruct, attrs_seaorm: SeaOrm) -> Result<TokenStream, crate::error::Error> {
+
+    let fields: Vec<IdentTypeTuple> = item
+        .fields
+        .into_iter()
+        .map(|field| {
+            (
+                field.ident.unwrap(),
+                field.ty,
+                field.attrs
+                    .into_iter()
+                    .any(|attr| {
+                        if let Ok(c) = SeaographyMutation::from_attributes(&[attr]) {
+                            c.skip.is_some()
+                        } else {
+                            false
+                        }
+                    })
+            )
+        })
+        .collect();
+
+    dbg!(fields.clone());
+
+
+    let name = if let syn::Lit::Str(item) = attrs_seaorm.table_name.as_ref().unwrap() {
+        Ok(item.value().parse::<TokenStream>()?)
+    } else {
+        Err(crate::error::Error::Internal(
+            "Unreachable parse of query entities".into(),
+        ))
+    }?;
+
+    let create_mutation_query = create_mutation(&name, &fields);
+    let delete_mutation_query = delete_mutation(&name);
+    let update_mutation_query = update_mutation(&name, &fields);
+
+    let struct_name = Ident::new(&format!("{}Mutation", &name), Span::call_site());
+
+    Ok(quote! {
+
+        #[derive(Default)]
+        pub struct #struct_name;
+
+        #[async_graphql::Object]
+        impl #struct_name {
+            #create_mutation_query
+            #delete_mutation_query
+            #update_mutation_query
+        }
+    })
+
+}
+
+pub fn create_mutation(name: &TokenStream, fields: &[IdentTypeTuple]) -> TokenStream {
+
+    let variables: Vec<TokenStream> = fields
+        .iter()
+        .filter(|(i, _, skip)| { dbg!(&*i); dbg!(&*skip); !*skip })
+        .map(|(i, tp, _)| {
+            quote! {
+                #i: #tp,
+            }
+        })
+        .collect();
+
+
+    let variables_set: Vec<TokenStream> = fields
+        .iter()
+        .filter(|(_, _, i)| { !*i })
+        .map(|(i, _, _)| {
+            quote! {
+                #i: Set(#i),
+            }
+        })
+        .collect();
+
+    let fn_name = Ident::new(&format!("create_{}", *name), Span::call_site());
+
+    quote! {
+
+        pub async fn #fn_name<'a>(
+            &self,
+            ctx: &async_graphql::Context<'a>,
+            #(#variables)*
+        ) -> async_graphql::Result<bool> {
+
+            use async_graphql::*;
+            use sea_orm::prelude::*;
+            use sea_orm::{NotSet, Set, IntoActiveModel, ActiveModelTrait, ModelTrait, EntityTrait, QueryFilter, ColumnTrait};
+
+            let db: &crate::DatabaseConnection = ctx.data::<crate::DatabaseConnection>().unwrap();
+            
+            let c = super::#name::ActiveModel {
+                #(#variables_set)*
+                ..Default::default()
+            };
+
+            let res = c.insert(db).await?;
+
+            Ok(true)
+        }
+    }
+}
+
+pub fn delete_mutation(name: &TokenStream) -> TokenStream {
+
+    let fn_name = Ident::new(&format!("delete_{}", *name), Span::call_site());
+
+    quote! {
+
+        pub async fn #fn_name<'a>(
+            &self,
+            ctx: &async_graphql::Context<'a>,
+            filters: super::#name::Filter,
+        ) -> async_graphql::Result<bool> {
+            use async_graphql::*;
+            use sea_orm::prelude::*;
+            use sea_orm::{EntityTrait};
+            use seaography::{EntityOrderBy, EntityFilter};
+
+            let db: &crate::DatabaseConnection = ctx.data::<crate::DatabaseConnection>().unwrap();
+            let res = super::#name::Entity::delete_many()
+                .filter(filters.filter_condition())
+                .exec(db)
+                .await?;
+
+            Ok(true)
+        }
+    }
+}
+
+
+
+
+pub fn update_mutation(name: &TokenStream, fields: &[IdentTypeTuple]) -> TokenStream {
+
+    let variables: Vec<TokenStream> = fields
+        .iter()
+        .filter(|(i, _, skip)| { dbg!(&*i); dbg!(&*skip); !*skip })
+        .map(|(i, tp, _)| {
+            quote! {
+                #i: Option<#tp>,
+            }
+        })
+        .collect();
+
+
+    let variables_set: Vec<TokenStream> = fields
+        .iter()
+        .filter(|(_, _, i)| { !*i })
+        .map(|(i, _, _)| {
+            quote! {
+                if let v = #i.unwrap() {
+                    c.#i = Set(v);
+                }
+            }
+        })
+        .collect();
+
+    let fn_name = Ident::new(&format!("update_{}", *name), Span::call_site());
+
+    quote! {
+
+        pub async fn #fn_name<'a>(
+            &self,
+            ctx: &async_graphql::Context<'a>,
+            filters: super::#name::Filter,
+            #(#variables)*
+        ) -> async_graphql::Result<bool> {
+
+            use async_graphql::*;
+            use sea_orm::prelude::*;
+            use sea_orm::{NotSet, Set, IntoActiveModel, ActiveModelTrait, ModelTrait, EntityTrait, QueryFilter, ColumnTrait};
+            use seaography::EntityFilter;
+
+            let db: &crate::DatabaseConnection = ctx.data::<crate::DatabaseConnection>().unwrap();
+            
+            let mut c: super::#name::ActiveModel =Default::default();
+
+            #(#variables_set)*
+
+            let res = super::#name::Entity::update_many()
+                .set(c)
+                .filter(filters.filter_condition())
+                .exec(db)
+                .await?;
+
+            Ok(true)
+        }
+    }
+}

--- a/derive/src/mutation.rs
+++ b/derive/src/mutation.rs
@@ -174,7 +174,10 @@ pub fn update_mutation(name: &TokenStream, fields: &[IdentTypeTuple]) -> TokenSt
         .filter(|(_, _, i)| { !*i })
         .map(|(i, _, _)| {
             quote! {
-                if let v = #i.unwrap() {
+
+                //c.#i = Set(v)
+
+                if let Some(v) = #i {
                     c.#i = Set(v);
                 }
             }


### PR DESCRIPTION
Hi :wave: 
First of all: Thank you for your work, I already learned a lot! :)
I experimented with graphql and SeaQL and wanted some mutations... So I tried to implement it, following the style of the existing macros.

This PR introduces the new derive macro `seaography::macros::Mutation` for every model/entity and `#[seaography_mutation(skip=true)]` for every record to be skipped.

I would love to hear for you if this code could be of any use.

## PR Info

<!-- mention the related issue -->
- Closes https://github.com/SeaQL/seaography/issues/9 https://github.com/SeaQL/seaography/issues/10 https://github.com/SeaQL/seaography/issues/11


## New Features

- [x] create mutations
- [x] update mutations
- [x] delete mutations

## Usage example:

examples/*/src/mutation_root.rs:
``` rust
use async_graphql::MergedObject;

#[derive(MergedObject, Default)]
pub struct MutationRoot(crate::entities::actor::actorMutation, crate::entities::address::addressMutation);
```

examples/*/src/entities/actor.rs:
``` rust
use sea_orm::entity::prelude::*;

#[derive(
    Clone,
    Debug,
    PartialEq,
    DeriveEntityModel,
    async_graphql::SimpleObject,
    seaography::macros::Filter,
    seaography::macros::Mutation
)]
#[sea_orm(table_name = "actor")]
#[graphql(complex)]
#[graphql(name = "Actor")]
pub struct Model {
    #[seaography_mutation(skip=true)]
    #[sea_orm(primary_key)]
    pub actor_id: i32,
    pub first_name: String,
    pub last_name: String,
    #[seaography_mutation(skip=true)]
    pub last_update: DateTime,
}

...
```

examples/*/src/entities/address.rs:
``` rust
use sea_orm::entity::prelude::*;

#[derive(
    Clone,
    Debug,
    PartialEq,
    DeriveEntityModel,
    async_graphql::SimpleObject,
    seaography::macros::Filter,
    seaography::macros::Mutation
)]
#[sea_orm(table_name = "address")]
#[graphql(complex)]
#[graphql(name = "Address")]
pub struct Model {
    #[seaography_mutation(skip=true)]
    #[sea_orm(primary_key)]
    pub address_id: i32,
    pub address: String,
    pub address2: Option<String>,
    pub district: String,
    pub city_id: i16,
    pub postal_code: Option<String>,
    pub phone: String,
    #[seaography_mutation(skip=true)]
    pub last_update: DateTime,
}
```

examples/*/src/main.rs
``` rust
    let mut schema = Schema::build(QueryRoot, MutationRoot::Default(), EmptySubscription)
        .data(database)
        .data(orm_dataloader);
```