### PR TITLE
`QueryRoot` derive attribute `object_config` takes any `TokenStream`

### DIFF
--- a/derive/src/root_query.rs
+++ b/derive/src/root_query.rs
@@ -4,7 +4,7 @@ use quote::{format_ident, quote};
 #[derive(Debug, Eq, PartialEq, bae::FromAttributes, Clone)]
 pub struct Seaography {
     entity: Option<syn::Lit>,
-    object_config: Option<syn::Expr>,
+    object_config: Option<syn::Lit>,
 }
 
 pub fn root_query_fn(
@@ -24,9 +24,10 @@ pub fn root_query_fn(
                     ))
                 }?;
 
-                let config = if let Some(config) = &attribute.object_config {
+                let config = if let Some(syn::Lit::Str(item)) = attribute.object_config.as_ref() {
+                    let tt = item.value().parse::<TokenStream>()?;
                     quote! {
-                        #[graphql(#config)]
+                        #[graphql(#tt)]
                     }
                 } else {
                     quote! {}

--- a/examples/mysql/src/query_root.rs
+++ b/examples/mysql/src/query_root.rs
@@ -14,5 +14,35 @@
 #[seaography(entity = "crate::entities::payment")]
 #[seaography(entity = "crate::entities::rental")]
 #[seaography(entity = "crate::entities::staff")]
-#[seaography(entity = "crate::entities::store")]
+#[seaography(
+    entity = "crate::entities::store",
+    object_config = "guard = \"RoleGuard::new(Role::Admin)\""
+)]
 pub struct QueryRoot;
+
+#[derive(Eq, PartialEq, Copy, Clone)]
+enum Role {
+    Admin,
+    Guest,
+}
+
+struct RoleGuard {
+    role: Role,
+}
+
+impl RoleGuard {
+    fn new(role: Role) -> Self {
+        Self { role }
+    }
+}
+
+#[async_trait::async_trait]
+impl async_graphql::Guard for RoleGuard {
+    async fn check(&self, ctx: &async_graphql::Context<'_>) -> async_graphql::Result<()> {
+        if ctx.data_opt::<Role>() == Some(&self.role) {
+            Ok(())
+        } else {
+            Err("Forbidden".into())
+        }
+    }
+}


### PR DESCRIPTION
## PR Info

- Closes https://github.com/SeaQL/seaography/discussions/117

## New Features

- [x] `QueryRoot` derive attribute `object_config` takes any `TokenStream`
