### PR TITLE
Fix LIKE and NOT LIKE Queries for Strings

### DIFF
--- a/examples/postgres/tests/mutation_tests.rs
+++ b/examples/postgres/tests/mutation_tests.rs
@@ -5,9 +5,7 @@ pub async fn get_schema() -> Schema {
     let database = Database::connect("postgres://sea:sea@127.0.0.1/sakila")
         .await
         .unwrap();
-    let schema =
-        seaography_postgres_example::query_root::schema(database, None, None)
-            .unwrap();
+    let schema = seaography_postgres_example::query_root::schema(database, None, None).unwrap();
 
     schema
 }

--- a/src/builder_context/filter_types_map.rs
+++ b/src/builder_context/filter_types_map.rs
@@ -528,28 +528,52 @@ impl FilterTypesMapHelper {
                     if let Some(value) = filter.get("starts_with") {
                         let value = types_map_helper
                             .async_graphql_value_to_sea_orm_value::<T>(column, &value)?;
-                        condition = condition.add(column.starts_with(&value.to_string()));
+
+                        let value: String = match value {
+                            sea_orm::Value::String(Some(inner)) => *inner,
+                            _ => value.to_string(),
+                        };
+
+                        condition = condition.add(column.starts_with(value));
                     }
                 }
                 FilterOperation::EndsWith => {
                     if let Some(value) = filter.get("ends_with") {
                         let value = types_map_helper
                             .async_graphql_value_to_sea_orm_value::<T>(column, &value)?;
-                        condition = condition.add(column.ends_with(&value.to_string()));
+
+                        let value: String = match value {
+                            sea_orm::Value::String(Some(inner)) => *inner,
+                            _ => value.to_string(),
+                        };
+
+                        condition = condition.add(column.ends_with(value));
                     }
                 }
                 FilterOperation::Like => {
                     if let Some(value) = filter.get("like") {
                         let value = types_map_helper
                             .async_graphql_value_to_sea_orm_value::<T>(column, &value)?;
-                        condition = condition.add(column.like(&value.to_string()));
+
+                        let value: String = match value {
+                            sea_orm::Value::String(Some(inner)) => *inner,
+                            _ => value.to_string(),
+                        };
+
+                        condition = condition.add(column.like(value));
                     }
                 }
                 FilterOperation::NotLike => {
                     if let Some(value) = filter.get("not_like") {
                         let value = types_map_helper
                             .async_graphql_value_to_sea_orm_value::<T>(column, &value)?;
-                        condition = condition.add(column.not_like(&value.to_string()));
+
+                        let value: String = match value {
+                            sea_orm::Value::String(Some(inner)) => *inner,
+                            _ => value.to_string(),
+                        };
+
+                        condition = condition.add(column.not_like(value));
                     }
                 }
                 FilterOperation::Between => {


### PR DESCRIPTION
## PR Info
This is a quick patch that fixes LIKE and NOT LIKE queries, which as far as I can tell, have never worked in seaography. The underlying `sea_orm` code works, but when stringifying the already String value, sea_orm quotes the value (presumably to prevent SQL injection?).

In other query filters, the filter conditions take a `sea_orm::Value` directly, which seems to do the correct thing (I didn't look that deeply at it, but `eq` works, for example). However, anything based on `LIKE` style queries (starts with, etc) take `String` inputs. If pulling the string from a `sea_orm::Value::to_string` call, you'll end up with a double-quoted string:

```
SELECT ... FROM ... WHERE "table"."column" LIKE "'cheese%'"
```

Which then fails to actually match anything.

<!-- is this PR depends on other PR? (if applicable) -->
- Dependencies:
N/A

<!-- any PR depends on this PR? (if applicable) -->
- Dependents:
N/A

## New Features
N/A

## Bug Fixes

- [ ] fixes LIKE and NOT LIKE queries when using string inputs.

## Breaking Changes
N/A

## Changes
N/A