### PR TITLE
Fix enum variant names in query filters and outputs

### DIFF
--- a/examples/postgres/src/query_root.rs
+++ b/examples/postgres/src/query_root.rs
@@ -1,9 +1,19 @@
 use crate::entities::*;
 use async_graphql::dynamic::*;
 use sea_orm::DatabaseConnection;
-use seaography::{Builder, BuilderContext};
+use seaography::{Builder, BuilderContext, ActiveEnumConfig, heck::ToSnakeCase};
 
-lazy_static::lazy_static! { static ref CONTEXT : BuilderContext = BuilderContext :: default () ; }
+lazy_static::lazy_static! {
+    static ref CONTEXT: BuilderContext = BuilderContext {
+        active_enum: ActiveEnumConfig {
+            variant_name: Box::new(|_enum_name: &str, variant: &str| -> String {
+                variant.to_snake_case()
+            }),
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+}
 
 pub fn schema(
     database: DatabaseConnection,

--- a/examples/postgres/tests/query_tests.rs
+++ b/examples/postgres/tests/query_tests.rs
@@ -843,7 +843,7 @@ async fn enumeration_filter() {
                 r#"
                 {
                   film(
-                    filters: { rating: { eq: NC17 } }
+                    filters: { rating: { eq: nc_17 } }
                     pagination: { page: { page: 1, limit: 5 } }
                   ) {
                     nodes {
@@ -861,23 +861,23 @@ async fn enumeration_filter() {
             "nodes": [
               {
                 "filmId": 27,
-                "rating": "NC17"
+                "rating": "nc_17"
               },
               {
                 "filmId": 29,
-                "rating": "NC17"
+                "rating": "nc_17"
               },
               {
                 "filmId": 31,
-                "rating": "NC17"
+                "rating": "nc_17"
               },
               {
                 "filmId": 34,
-                "rating": "NC17"
+                "rating": "nc_17"
               },
               {
                 "filmId": 38,
-                "rating": "NC17"
+                "rating": "nc_17"
               }
             ]
           }

--- a/src/builder_context/filter_types_map.rs
+++ b/src/builder_context/filter_types_map.rs
@@ -410,8 +410,14 @@ impl FilterTypesMapHelper {
                 FilterType::Float => &self.context.filter_types.float_filter_info,
                 FilterType::Boolean => &self.context.filter_types.boolean_filter_info,
                 FilterType::Id => &self.context.filter_types.id_filter_info,
-                FilterType::Enumeration(_) => {
-                    return prepare_enumeration_condition::<T>(filter, column, condition)
+                FilterType::Enumeration(name) => {
+                    return prepare_enumeration_condition::<T>(
+                        self.context,
+                        filter,
+                        column,
+                        condition,
+                        &name,
+                    );
                 }
                 FilterType::Custom(_) => {
                     let entity_object_builder = EntityObjectBuilder {

--- a/src/inputs/active_enum_filter_input.rs
+++ b/src/inputs/active_enum_filter_input.rs
@@ -72,9 +72,11 @@ impl ActiveEnumFilterInputBuilder {
 
 /// used to update the query condition with enumeration filters
 pub fn prepare_enumeration_condition<T>(
+    context: &'static BuilderContext,
     filter: &ObjectAccessor,
     column: &T::Column,
     condition: Condition,
+    type_name: &str,
 ) -> SeaResult<Condition>
 where
     T: EntityTrait,
@@ -87,12 +89,14 @@ where
     };
 
     let extract_variant = move |input: &str| -> String {
-        let variant = variants.iter().find(|variant| {
-            let variant = variant
-                .to_string()
-                .to_upper_camel_case()
-                .to_ascii_uppercase();
-            variant.eq(input)
+        let variant = variants.iter().find(|orm_variant| {
+            let orm_variant = orm_variant.to_string();
+
+            let builder = ActiveEnumBuilder { context };
+
+            let gql_variant = builder.variant_name(type_name, &orm_variant);
+
+            gql_variant.eq(input)
         });
         variant.unwrap().to_string()
     };

--- a/src/outputs/entity_object.rs
+++ b/src/outputs/entity_object.rs
@@ -27,7 +27,7 @@ impl std::default::Default for EntityObjectConfig {
     }
 }
 
-use crate::{BuilderContext, GuardAction, TypesMapHelper};
+use crate::{ActiveEnumBuilder, BuilderContext, GuardAction, TypesMapHelper};
 
 /// This builder produces the GraphQL object of a SeaORM entity
 pub struct EntityObjectBuilder {
@@ -105,6 +105,8 @@ impl EntityObjectBuilder {
         };
 
         T::Column::iter().fold(Object::new(object_name), |object, column: T::Column| {
+            let context = self.context;
+
             let column_name = self.column_name::<T>(&column);
 
             let column_def = column.def();
@@ -129,14 +131,12 @@ impl EntityObjectBuilder {
                 _ => false,
             };
 
-            let guard = self
-                .context
+            let guard = context
                 .guards
                 .field_guards
                 .get(&format!("{}.{}", &object_name, &column_name));
 
-            let conversion_fn = self
-                .context
+            let conversion_fn = context
                 .types
                 .output_conversions
                 .get(&format!("{}.{}", entity_name, column_name));
@@ -179,12 +179,14 @@ impl EntityObjectBuilder {
                     });
                 }
 
-                FieldFuture::new(async move {
-                    Ok(sea_query_value_to_graphql_value(
-                        object.get(column),
-                        is_enum,
-                    ))
-                })
+                let value = sea_query_value_to_graphql_value(
+                    context,
+                    object.get(column),
+                    is_enum,
+                    column_def.get_column_type(),
+                );
+
+                FieldFuture::new(async move { Ok(value) })
             });
 
             object.field(field)
@@ -193,8 +195,10 @@ impl EntityObjectBuilder {
 }
 
 fn sea_query_value_to_graphql_value(
+    context: &'static BuilderContext,
     sea_query_value: sea_orm::sea_query::Value,
     is_enum: bool,
+    column_type: &ColumnType,
 ) -> Option<Value> {
     match sea_query_value {
         sea_orm::Value::Bool(value) => value.map(Value::from),
@@ -208,9 +212,18 @@ fn sea_query_value_to_graphql_value(
         sea_orm::Value::BigUnsigned(value) => value.map(Value::from),
         sea_orm::Value::Float(value) => value.map(Value::from),
         sea_orm::Value::Double(value) => value.map(Value::from),
-        sea_orm::Value::String(value) if is_enum => {
-            value.map(|it| Value::from(it.as_str().to_upper_camel_case().to_ascii_uppercase()))
-        }
+        sea_orm::Value::String(value) if is_enum => value.map(|it| {
+            let builder = ActiveEnumBuilder { context };
+
+            let enum_name = match column_type {
+                ColumnType::Enum { name, .. } => name.to_string(),
+                _ => panic!("Expected enum column type"),
+            };
+
+            let gql_name = builder.variant_name(enum_name.as_str(), it.as_str());
+
+            Value::from(gql_name)
+        }),
         sea_orm::Value::String(value) => value.map(|it| Value::from(it.as_str())),
         sea_orm::Value::Char(value) => value.map(|it| Value::from(it.to_string())),
 
@@ -222,7 +235,8 @@ fn sea_query_value_to_graphql_value(
             Value::List(
                 it.into_iter()
                     .map(|item| {
-                        sea_query_value_to_graphql_value(item, is_enum).unwrap_or(Value::Null)
+                        sea_query_value_to_graphql_value(context, item, is_enum, column_type)
+                            .unwrap_or(Value::Null)
                     })
                     .collect(),
             )


### PR DESCRIPTION
## PR Info

The custom naming functions you can supply via the `BuilderContext` 
are not used for enum variants.  Instead, upper camel case is hardcoded there.

Not sure if there are more places where this is an issue, I think the mutations part is still missing, but I was not able to test that yet.

I also modified the existing test to use a custom naming function.

## Bug Fixes

- Use custom naming functions for enum variant input / output
