### PR TITLE
Fix: `LIKE` wildcard operations

### DIFF
--- a/src/builder_context/filter_types_map.rs
+++ b/src/builder_context/filter_types_map.rs
@@ -522,28 +522,44 @@ impl FilterTypesMapHelper {
                     if let Some(value) = filter.get("contains") {
                         let value = types_map_helper
                             .async_graphql_value_to_sea_orm_value::<T>(column, &value)?;
-                        condition = condition.add(column.contains(value.to_string()));
+                        let s = match value {
+                            sea_orm::sea_query::Value::String(Some(s)) => s.to_string(),
+                            _ => value.to_string(),
+                        };
+                        condition = condition.add(column.contains(s));
                     }
                 }
                 FilterOperation::StartsWith => {
                     if let Some(value) = filter.get("starts_with") {
                         let value = types_map_helper
                             .async_graphql_value_to_sea_orm_value::<T>(column, &value)?;
-                        condition = condition.add(column.starts_with(value.to_string()));
+                        let s = match value {
+                            sea_orm::sea_query::Value::String(Some(s)) => s.to_string(),
+                            _ => value.to_string(),
+                        };
+                        condition = condition.add(column.starts_with(s));
                     }
                 }
                 FilterOperation::EndsWith => {
                     if let Some(value) = filter.get("ends_with") {
                         let value = types_map_helper
                             .async_graphql_value_to_sea_orm_value::<T>(column, &value)?;
-                        condition = condition.add(column.ends_with(value.to_string()));
+                        let s = match value {
+                            sea_orm::sea_query::Value::String(Some(s)) => s.to_string(),
+                            _ => value.to_string(),
+                        };
+                        condition = condition.add(column.ends_with(s));
                     }
                 }
                 FilterOperation::Like => {
                     if let Some(value) = filter.get("like") {
                         let value = types_map_helper
                             .async_graphql_value_to_sea_orm_value::<T>(column, &value)?;
-                        condition = condition.add(column.like(value.to_string()));
+                        let s = match value {
+                            sea_orm::sea_query::Value::String(Some(s)) => s.to_string(),
+                            _ => value.to_string(),
+                        };
+                        condition = condition.add(column.like(s));
                     }
                 }
                 FilterOperation::NotLike => {


### PR DESCRIPTION
## PR Info

## Bug Fixes

- [x] Fix: `LIKE` wildcard operations
```
// Before
SELECT ... FROM ... WHERE col LIKE "'string'"

// After
SELECT ... FROM ... WHERE col LIKE "string"
```