### PR TITLE
feat(json): Add feature to expose JSON as raw scalar

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ serde_json = { version = "1.0" }
 [features]
 default = ["field-camel-case"]
 with-json = ["sea-orm/with-json"]
+with-json-as-scalar = ["with-json"]
 with-chrono = ["sea-orm/with-chrono", "async-graphql/chrono"]
 with-time = ["sea-orm/with-time", "async-graphql/time"]
 with-uuid = ["sea-orm/with-uuid"]

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -316,6 +316,15 @@ impl Builder {
             .into_iter()
             .fold(schema, |schema, cur| schema.register(cur));
 
+        #[cfg(feature = "with-json-as-scalar")]
+        let schema = schema.register(
+            async_graphql::dynamic::Scalar::new(&self.context.types.json_name)
+                .description("The `JSON` scalar type represents raw JSON values")
+                .specified_by_url(
+                    "http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf",
+                ),
+        );
+
         let schema = schema
             .register(
                 OrderByEnumBuilder {

--- a/src/outputs/entity_object.rs
+++ b/src/outputs/entity_object.rs
@@ -236,7 +236,13 @@ fn sea_query_value_to_graphql_value(
 
         #[cfg(feature = "with-json")]
         #[cfg_attr(docsrs, doc(cfg(feature = "with-json")))]
-        sea_orm::sea_query::Value::Json(value) => value.map(|it| Value::from(it.to_string())),
+        sea_orm::sea_query::Value::Json(value) => value.map(|it| {
+            if cfg!(feature = "with-json-as-scalar") {
+                Value::from_json((*it).clone()).expect("Unable to serialize")
+            } else {
+                Value::from(it.to_string())
+            }
+        }),
 
         #[cfg(feature = "with-chrono")]
         #[cfg_attr(docsrs, doc(cfg(feature = "with-chrono")))]


### PR DESCRIPTION
## New Features

- [ ] Add a new feature flag to expose JSON as a raw scalar
  When enabled, all JSON object will be exposed with a new scalar type `Json` instead of a string.
- [ ] Expose the scalar name in `TypesMapConfig`

## Breaking Changes

- [ ] I think none, most of the code is disabled by default
