### PR TITLE
Re-export `async_graphql` and `lazy_static`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ itertools = { version = "0.12.0" }
 heck = { version = "0.4.1" }
 thiserror = { version = "1.0.44" }
 fnv = { version = "1.0.7" }
+lazy_static = { version = "1.5" }
 
 [features]
 default = ["field-camel-case"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ categories = ["database"]
 
 [dependencies]
 async-graphql = { version = "7.0", features = ["decimal", "chrono", "dataloader", "dynamic-schema"] }
-sea-orm = { version = "~1.1.2", default-features = false, features = ["seaography"] }
+sea-orm = { version = "~1.1.4", default-features = false, features = ["seaography"] }
 itertools = { version = "0.12.0" }
 heck = { version = "0.4.1" }
 thiserror = { version = "1.0.44" }

--- a/examples/mysql/Cargo.toml
+++ b/examples/mysql/Cargo.toml
@@ -7,7 +7,7 @@ version = "1.1.2"
 axum = { version = "0.7" }
 async-graphql-axum = { version = "7.0" }
 dotenv = "0.15.0"
-sea-orm = { version = "~1.1.2", features = ["sqlx-mysql", "runtime-async-std-native-tls", "seaography"] }
+sea-orm = { version = "~1.1.4", features = ["sqlx-mysql", "runtime-async-std-native-tls", "seaography"] }
 tokio = { version = "1.29.1", features = ["macros", "rt-multi-thread"] }
 tracing = { version = "0.1.37" }
 tracing-subscriber = { version = "0.3.17" }

--- a/examples/mysql/Cargo.toml
+++ b/examples/mysql/Cargo.toml
@@ -6,13 +6,11 @@ version = "1.1.2"
 [dependencies]
 axum = { version = "0.7" }
 async-graphql-axum = { version = "7.0" }
-async-graphql = { version = "7.0", features = ["decimal", "chrono", "dataloader", "dynamic-schema"] }
 dotenv = "0.15.0"
 sea-orm = { version = "~1.1.2", features = ["sqlx-mysql", "runtime-async-std-native-tls", "seaography"] }
 tokio = { version = "1.29.1", features = ["macros", "rt-multi-thread"] }
 tracing = { version = "0.1.37" }
 tracing-subscriber = { version = "0.3.17" }
-lazy_static = { version = "1.4.0" }
 
 [dependencies.seaography]
 path = "../../"

--- a/examples/mysql/src/main.rs
+++ b/examples/mysql/src/main.rs
@@ -7,8 +7,7 @@ use axum::{
 };
 use dotenv::dotenv;
 use sea_orm::Database;
-use seaography::async_graphql;
-use seaography::lazy_static;
+use seaography::{async_graphql, lazy_static};
 use std::env;
 use tokio::net::TcpListener;
 

--- a/examples/mysql/src/main.rs
+++ b/examples/mysql/src/main.rs
@@ -1,3 +1,4 @@
+use seaography::async_graphql;
 use async_graphql::http::{playground_source, GraphQLPlaygroundConfig};
 use async_graphql_axum::GraphQL;
 use axum::{
@@ -6,12 +7,12 @@ use axum::{
     Router,
 };
 use dotenv::dotenv;
-use lazy_static::lazy_static;
+use seaography::lazy_static;
 use sea_orm::Database;
 use std::env;
 use tokio::net::TcpListener;
 
-lazy_static! {
+lazy_static::lazy_static! {
     static ref URL: String = env::var("URL").unwrap_or("localhost:8000".into());
     static ref ENDPOINT: String = env::var("ENDPOINT").unwrap_or("/".into());
     static ref DATABASE_URL: String =

--- a/examples/mysql/src/main.rs
+++ b/examples/mysql/src/main.rs
@@ -1,4 +1,3 @@
-use seaography::async_graphql;
 use async_graphql::http::{playground_source, GraphQLPlaygroundConfig};
 use async_graphql_axum::GraphQL;
 use axum::{
@@ -7,8 +6,9 @@ use axum::{
     Router,
 };
 use dotenv::dotenv;
-use seaography::lazy_static;
 use sea_orm::Database;
+use seaography::async_graphql;
+use seaography::lazy_static;
 use std::env;
 use tokio::net::TcpListener;
 

--- a/examples/mysql/src/query_root.rs
+++ b/examples/mysql/src/query_root.rs
@@ -1,8 +1,8 @@
 use crate::entities::*;
-use seaography::async_graphql;
-use seaography::lazy_static;
 use async_graphql::dynamic::*;
 use sea_orm::DatabaseConnection;
+use seaography::async_graphql;
+use seaography::lazy_static;
 use seaography::{Builder, BuilderContext};
 
 lazy_static::lazy_static! { static ref CONTEXT : BuilderContext = BuilderContext :: default () ; }

--- a/examples/mysql/src/query_root.rs
+++ b/examples/mysql/src/query_root.rs
@@ -1,9 +1,7 @@
 use crate::entities::*;
 use async_graphql::dynamic::*;
 use sea_orm::DatabaseConnection;
-use seaography::async_graphql;
-use seaography::lazy_static;
-use seaography::{Builder, BuilderContext};
+use seaography::{async_graphql, lazy_static, Builder, BuilderContext};
 
 lazy_static::lazy_static! { static ref CONTEXT : BuilderContext = BuilderContext :: default () ; }
 

--- a/examples/mysql/src/query_root.rs
+++ b/examples/mysql/src/query_root.rs
@@ -1,4 +1,6 @@
 use crate::entities::*;
+use seaography::async_graphql;
+use seaography::lazy_static;
 use async_graphql::dynamic::*;
 use sea_orm::DatabaseConnection;
 use seaography::{Builder, BuilderContext};

--- a/examples/mysql/tests/guard_mutation_tests.rs
+++ b/examples/mysql/tests/guard_mutation_tests.rs
@@ -1,9 +1,9 @@
 use std::collections::BTreeMap;
 
-use seaography::async_graphql;
-use seaography::lazy_static;
 use async_graphql::{dynamic::*, Response};
 use sea_orm::{Database, DatabaseConnection};
+use seaography::async_graphql;
+use seaography::lazy_static;
 use seaography::{Builder, BuilderContext, FnGuard, GuardsConfig};
 use seaography_mysql_example::entities::*;
 

--- a/examples/mysql/tests/guard_mutation_tests.rs
+++ b/examples/mysql/tests/guard_mutation_tests.rs
@@ -2,9 +2,7 @@ use std::collections::BTreeMap;
 
 use async_graphql::{dynamic::*, Response};
 use sea_orm::{Database, DatabaseConnection};
-use seaography::async_graphql;
-use seaography::lazy_static;
-use seaography::{Builder, BuilderContext, FnGuard, GuardsConfig};
+use seaography::{async_graphql, lazy_static, Builder, BuilderContext, FnGuard, GuardsConfig};
 use seaography_mysql_example::entities::*;
 
 lazy_static::lazy_static! {

--- a/examples/mysql/tests/guard_mutation_tests.rs
+++ b/examples/mysql/tests/guard_mutation_tests.rs
@@ -1,5 +1,7 @@
 use std::collections::BTreeMap;
 
+use seaography::async_graphql;
+use seaography::lazy_static;
 use async_graphql::{dynamic::*, Response};
 use sea_orm::{Database, DatabaseConnection};
 use seaography::{Builder, BuilderContext, FnGuard, GuardsConfig};

--- a/examples/mysql/tests/guard_tests.rs
+++ b/examples/mysql/tests/guard_tests.rs
@@ -1,9 +1,9 @@
 use std::collections::BTreeMap;
 
-use seaography::async_graphql;
-use seaography::lazy_static;
 use async_graphql::{dynamic::*, Response};
 use sea_orm::{Database, DatabaseConnection, RelationTrait};
+use seaography::async_graphql;
+use seaography::lazy_static;
 use seaography::{
     Builder, BuilderContext, EntityObjectRelationBuilder, EntityObjectViaRelationBuilder, FnGuard,
     GuardsConfig,

--- a/examples/mysql/tests/guard_tests.rs
+++ b/examples/mysql/tests/guard_tests.rs
@@ -2,11 +2,9 @@ use std::collections::BTreeMap;
 
 use async_graphql::{dynamic::*, Response};
 use sea_orm::{Database, DatabaseConnection, RelationTrait};
-use seaography::async_graphql;
-use seaography::lazy_static;
 use seaography::{
-    Builder, BuilderContext, EntityObjectRelationBuilder, EntityObjectViaRelationBuilder, FnGuard,
-    GuardsConfig,
+    async_graphql, lazy_static, Builder, BuilderContext, EntityObjectRelationBuilder,
+    EntityObjectViaRelationBuilder, FnGuard, GuardsConfig,
 };
 
 lazy_static::lazy_static! {

--- a/examples/mysql/tests/guard_tests.rs
+++ b/examples/mysql/tests/guard_tests.rs
@@ -1,5 +1,7 @@
 use std::collections::BTreeMap;
 
+use seaography::async_graphql;
+use seaography::lazy_static;
 use async_graphql::{dynamic::*, Response};
 use sea_orm::{Database, DatabaseConnection, RelationTrait};
 use seaography::{

--- a/examples/mysql/tests/mutation_tests.rs
+++ b/examples/mysql/tests/mutation_tests.rs
@@ -1,6 +1,6 @@
-use seaography::async_graphql;
 use async_graphql::{dynamic::*, Response};
 use sea_orm::Database;
+use seaography::async_graphql;
 
 async fn main() {
     test_simple_insert_one().await;

--- a/examples/mysql/tests/mutation_tests.rs
+++ b/examples/mysql/tests/mutation_tests.rs
@@ -1,3 +1,4 @@
+use seaography::async_graphql;
 use async_graphql::{dynamic::*, Response};
 use sea_orm::Database;
 

--- a/examples/mysql/tests/query_tests.rs
+++ b/examples/mysql/tests/query_tests.rs
@@ -1,6 +1,6 @@
-use seaography::async_graphql;
 use async_graphql::{dynamic::*, Response};
 use sea_orm::Database;
+use seaography::async_graphql;
 
 pub async fn get_schema() -> Schema {
     let database = Database::connect("mysql://sea:sea@127.0.0.1/sakila")

--- a/examples/mysql/tests/query_tests.rs
+++ b/examples/mysql/tests/query_tests.rs
@@ -1,3 +1,4 @@
+use seaography::async_graphql;
 use async_graphql::{dynamic::*, Response};
 use sea_orm::Database;
 

--- a/examples/postgres/Cargo.toml
+++ b/examples/postgres/Cargo.toml
@@ -7,7 +7,7 @@ version = "1.1.2"
 poem = { version = "3.0" }
 async-graphql-poem = { version = "7.0" }
 dotenv = "0.15.0"
-sea-orm = { version = "~1.1.2", features = ["sqlx-postgres", "runtime-async-std-native-tls", "seaography"] }
+sea-orm = { version = "~1.1.4", features = ["sqlx-postgres", "runtime-async-std-native-tls", "seaography"] }
 tokio = { version = "1.29.1", features = ["macros", "rt-multi-thread"] }
 tracing = { version = "0.1.37" }
 tracing-subscriber = { version = "0.3.17" }

--- a/examples/postgres/Cargo.toml
+++ b/examples/postgres/Cargo.toml
@@ -6,13 +6,11 @@ version = "1.1.2"
 [dependencies]
 poem = { version = "3.0" }
 async-graphql-poem = { version = "7.0" }
-async-graphql = { version = "7.0", features = ["decimal", "chrono", "dataloader", "dynamic-schema"] }
 dotenv = "0.15.0"
 sea-orm = { version = "~1.1.2", features = ["sqlx-postgres", "runtime-async-std-native-tls", "seaography"] }
 tokio = { version = "1.29.1", features = ["macros", "rt-multi-thread"] }
 tracing = { version = "0.1.37" }
 tracing-subscriber = { version = "0.3.17" }
-lazy_static = { version = "1.4.0" }
 
 [dependencies.seaography]
 path = "../../"

--- a/examples/postgres/src/main.rs
+++ b/examples/postgres/src/main.rs
@@ -1,10 +1,10 @@
-use seaography::async_graphql;
 use async_graphql::http::{playground_source, GraphQLPlaygroundConfig};
 use async_graphql_poem::GraphQL;
 use dotenv::dotenv;
-use seaography::lazy_static;
 use poem::{get, handler, listener::TcpListener, web::Html, IntoResponse, Route, Server};
 use sea_orm::Database;
+use seaography::async_graphql;
+use seaography::lazy_static;
 use std::env;
 
 lazy_static::lazy_static! {

--- a/examples/postgres/src/main.rs
+++ b/examples/postgres/src/main.rs
@@ -1,12 +1,13 @@
+use seaography::async_graphql;
 use async_graphql::http::{playground_source, GraphQLPlaygroundConfig};
 use async_graphql_poem::GraphQL;
 use dotenv::dotenv;
-use lazy_static::lazy_static;
+use seaography::lazy_static;
 use poem::{get, handler, listener::TcpListener, web::Html, IntoResponse, Route, Server};
 use sea_orm::Database;
 use std::env;
 
-lazy_static! {
+lazy_static::lazy_static! {
     static ref URL: String = env::var("URL").unwrap_or("localhost:8000".into());
     static ref ENDPOINT: String = env::var("ENDPOINT").unwrap_or("/".into());
     static ref DATABASE_URL: String =

--- a/examples/postgres/src/main.rs
+++ b/examples/postgres/src/main.rs
@@ -3,8 +3,7 @@ use async_graphql_poem::GraphQL;
 use dotenv::dotenv;
 use poem::{get, handler, listener::TcpListener, web::Html, IntoResponse, Route, Server};
 use sea_orm::Database;
-use seaography::async_graphql;
-use seaography::lazy_static;
+use seaography::{async_graphql, lazy_static};
 use std::env;
 
 lazy_static::lazy_static! {

--- a/examples/postgres/src/query_root.rs
+++ b/examples/postgres/src/query_root.rs
@@ -1,8 +1,8 @@
 use crate::entities::*;
-use seaography::async_graphql;
-use seaography::lazy_static;
 use async_graphql::dynamic::*;
 use sea_orm::DatabaseConnection;
+use seaography::async_graphql;
+use seaography::lazy_static;
 use seaography::{Builder, BuilderContext};
 
 lazy_static::lazy_static! { static ref CONTEXT : BuilderContext = BuilderContext :: default () ; }

--- a/examples/postgres/src/query_root.rs
+++ b/examples/postgres/src/query_root.rs
@@ -1,9 +1,7 @@
 use crate::entities::*;
 use async_graphql::dynamic::*;
 use sea_orm::DatabaseConnection;
-use seaography::async_graphql;
-use seaography::lazy_static;
-use seaography::{Builder, BuilderContext};
+use seaography::{async_graphql, lazy_static, Builder, BuilderContext};
 
 lazy_static::lazy_static! { static ref CONTEXT : BuilderContext = BuilderContext :: default () ; }
 

--- a/examples/postgres/src/query_root.rs
+++ b/examples/postgres/src/query_root.rs
@@ -1,4 +1,6 @@
 use crate::entities::*;
+use seaography::async_graphql;
+use seaography::lazy_static;
 use async_graphql::dynamic::*;
 use sea_orm::DatabaseConnection;
 use seaography::{Builder, BuilderContext};

--- a/examples/postgres/tests/guard_mutation_tests.rs
+++ b/examples/postgres/tests/guard_mutation_tests.rs
@@ -1,9 +1,9 @@
 use std::collections::BTreeMap;
 
-use seaography::async_graphql;
-use seaography::lazy_static;
 use async_graphql::{dynamic::*, Response};
 use sea_orm::{Database, DatabaseConnection};
+use seaography::async_graphql;
+use seaography::lazy_static;
 use seaography::{Builder, BuilderContext, FnGuard, GuardsConfig};
 use seaography_postgres_example::entities::*;
 

--- a/examples/postgres/tests/guard_mutation_tests.rs
+++ b/examples/postgres/tests/guard_mutation_tests.rs
@@ -1,5 +1,7 @@
 use std::collections::BTreeMap;
 
+use seaography::async_graphql;
+use seaography::lazy_static;
 use async_graphql::{dynamic::*, Response};
 use sea_orm::{Database, DatabaseConnection};
 use seaography::{Builder, BuilderContext, FnGuard, GuardsConfig};

--- a/examples/postgres/tests/guard_mutation_tests.rs
+++ b/examples/postgres/tests/guard_mutation_tests.rs
@@ -2,9 +2,7 @@ use std::collections::BTreeMap;
 
 use async_graphql::{dynamic::*, Response};
 use sea_orm::{Database, DatabaseConnection};
-use seaography::async_graphql;
-use seaography::lazy_static;
-use seaography::{Builder, BuilderContext, FnGuard, GuardsConfig};
+use seaography::{async_graphql, lazy_static, Builder, BuilderContext, FnGuard, GuardsConfig};
 use seaography_postgres_example::entities::*;
 
 lazy_static::lazy_static! {

--- a/examples/postgres/tests/guard_tests.rs
+++ b/examples/postgres/tests/guard_tests.rs
@@ -1,9 +1,9 @@
 use std::collections::BTreeMap;
 
-use seaography::async_graphql;
-use seaography::lazy_static;
 use async_graphql::{dynamic::*, Response};
 use sea_orm::{Database, DatabaseConnection, RelationTrait};
+use seaography::async_graphql;
+use seaography::lazy_static;
 use seaography::{
     Builder, BuilderContext, EntityObjectRelationBuilder, EntityObjectViaRelationBuilder, FnGuard,
     GuardsConfig,

--- a/examples/postgres/tests/guard_tests.rs
+++ b/examples/postgres/tests/guard_tests.rs
@@ -2,11 +2,9 @@ use std::collections::BTreeMap;
 
 use async_graphql::{dynamic::*, Response};
 use sea_orm::{Database, DatabaseConnection, RelationTrait};
-use seaography::async_graphql;
-use seaography::lazy_static;
 use seaography::{
-    Builder, BuilderContext, EntityObjectRelationBuilder, EntityObjectViaRelationBuilder, FnGuard,
-    GuardsConfig,
+    async_graphql, lazy_static, Builder, BuilderContext, EntityObjectRelationBuilder,
+    EntityObjectViaRelationBuilder, FnGuard, GuardsConfig,
 };
 
 lazy_static::lazy_static! {

--- a/examples/postgres/tests/guard_tests.rs
+++ b/examples/postgres/tests/guard_tests.rs
@@ -1,5 +1,7 @@
 use std::collections::BTreeMap;
 
+use seaography::async_graphql;
+use seaography::lazy_static;
 use async_graphql::{dynamic::*, Response};
 use sea_orm::{Database, DatabaseConnection, RelationTrait};
 use seaography::{

--- a/examples/postgres/tests/mutation_tests.rs
+++ b/examples/postgres/tests/mutation_tests.rs
@@ -1,6 +1,6 @@
-use seaography::async_graphql;
 use async_graphql::{dynamic::*, Response};
 use sea_orm::Database;
+use seaography::async_graphql;
 
 #[tokio::test]
 async fn main() {

--- a/examples/postgres/tests/mutation_tests.rs
+++ b/examples/postgres/tests/mutation_tests.rs
@@ -1,3 +1,4 @@
+use seaography::async_graphql;
 use async_graphql::{dynamic::*, Response};
 use sea_orm::Database;
 

--- a/examples/postgres/tests/query_tests.rs
+++ b/examples/postgres/tests/query_tests.rs
@@ -1,6 +1,6 @@
-use seaography::async_graphql;
 use async_graphql::{dynamic::*, Response};
 use sea_orm::Database;
+use seaography::async_graphql;
 
 pub async fn get_schema() -> Schema {
     let database = Database::connect("postgres://sea:sea@127.0.0.1/sakila")

--- a/examples/postgres/tests/query_tests.rs
+++ b/examples/postgres/tests/query_tests.rs
@@ -1,3 +1,4 @@
+use seaography::async_graphql;
 use async_graphql::{dynamic::*, Response};
 use sea_orm::Database;
 

--- a/examples/sqlite/Cargo.toml
+++ b/examples/sqlite/Cargo.toml
@@ -6,13 +6,11 @@ version = "1.1.2"
 [dependencies]
 actix-web = { version = "4.5", default-features = false, features = ["macros"] }
 async-graphql-actix-web = { version = "7.0" }
-async-graphql = { version = "7.0", features = ["decimal", "chrono", "dataloader", "dynamic-schema"] }
 dotenv = "0.15.0"
 sea-orm = { version = "~1.1.2", features = ["sqlx-sqlite", "runtime-async-std-rustls", "seaography"] }
 tokio = { version = "1.29.1", features = ["macros", "rt-multi-thread"] }
 tracing = { version = "0.1.37" }
 tracing-subscriber = { version = "0.3.17" }
-lazy_static = { version = "1.4.0" }
 
 [dependencies.seaography]
 path = "../../"

--- a/examples/sqlite/Cargo.toml
+++ b/examples/sqlite/Cargo.toml
@@ -7,7 +7,7 @@ version = "1.1.2"
 actix-web = { version = "4.5", default-features = false, features = ["macros"] }
 async-graphql-actix-web = { version = "7.0" }
 dotenv = "0.15.0"
-sea-orm = { version = "~1.1.2", features = ["sqlx-sqlite", "runtime-async-std-rustls", "seaography"] }
+sea-orm = { version = "~1.1.4", features = ["sqlx-sqlite", "runtime-async-std-rustls", "seaography"] }
 tokio = { version = "1.29.1", features = ["macros", "rt-multi-thread"] }
 tracing = { version = "0.1.37" }
 tracing-subscriber = { version = "0.3.17" }

--- a/examples/sqlite/src/main.rs
+++ b/examples/sqlite/src/main.rs
@@ -6,8 +6,7 @@ use async_graphql::{
 use async_graphql_actix_web::{GraphQLRequest, GraphQLResponse};
 use dotenv::dotenv;
 use sea_orm::Database;
-use seaography::async_graphql;
-use seaography::lazy_static;
+use seaography::{async_graphql, lazy_static};
 use std::env;
 
 lazy_static::lazy_static! {

--- a/examples/sqlite/src/main.rs
+++ b/examples/sqlite/src/main.rs
@@ -1,13 +1,13 @@
 use actix_web::{guard, web, web::Data, App, HttpResponse, HttpServer, Result};
-use seaography::async_graphql;
 use async_graphql::{
     dynamic::*,
     http::{playground_source, GraphQLPlaygroundConfig},
 };
 use async_graphql_actix_web::{GraphQLRequest, GraphQLResponse};
 use dotenv::dotenv;
-use seaography::lazy_static;
 use sea_orm::Database;
+use seaography::async_graphql;
+use seaography::lazy_static;
 use std::env;
 
 lazy_static::lazy_static! {

--- a/examples/sqlite/src/main.rs
+++ b/examples/sqlite/src/main.rs
@@ -1,15 +1,16 @@
 use actix_web::{guard, web, web::Data, App, HttpResponse, HttpServer, Result};
+use seaography::async_graphql;
 use async_graphql::{
     dynamic::*,
     http::{playground_source, GraphQLPlaygroundConfig},
 };
 use async_graphql_actix_web::{GraphQLRequest, GraphQLResponse};
 use dotenv::dotenv;
-use lazy_static::lazy_static;
+use seaography::lazy_static;
 use sea_orm::Database;
 use std::env;
 
-lazy_static! {
+lazy_static::lazy_static! {
     static ref URL: String = env::var("URL").unwrap_or("localhost:8000".into());
     static ref ENDPOINT: String = env::var("ENDPOINT").unwrap_or("/".into());
     static ref DATABASE_URL: String =

--- a/examples/sqlite/src/query_root.rs
+++ b/examples/sqlite/src/query_root.rs
@@ -1,8 +1,8 @@
 use crate::entities::*;
-use seaography::async_graphql;
-use seaography::lazy_static;
 use async_graphql::dynamic::*;
 use sea_orm::DatabaseConnection;
+use seaography::async_graphql;
+use seaography::lazy_static;
 use seaography::{Builder, BuilderContext};
 
 lazy_static::lazy_static! { static ref CONTEXT : BuilderContext = BuilderContext :: default () ; }

--- a/examples/sqlite/src/query_root.rs
+++ b/examples/sqlite/src/query_root.rs
@@ -1,9 +1,7 @@
 use crate::entities::*;
 use async_graphql::dynamic::*;
 use sea_orm::DatabaseConnection;
-use seaography::async_graphql;
-use seaography::lazy_static;
-use seaography::{Builder, BuilderContext};
+use seaography::{async_graphql, lazy_static, Builder, BuilderContext};
 
 lazy_static::lazy_static! { static ref CONTEXT : BuilderContext = BuilderContext :: default () ; }
 

--- a/examples/sqlite/src/query_root.rs
+++ b/examples/sqlite/src/query_root.rs
@@ -1,4 +1,6 @@
 use crate::entities::*;
+use seaography::async_graphql;
+use seaography::lazy_static;
 use async_graphql::dynamic::*;
 use sea_orm::DatabaseConnection;
 use seaography::{Builder, BuilderContext};

--- a/examples/sqlite/tests/guard_mutation_tests.rs
+++ b/examples/sqlite/tests/guard_mutation_tests.rs
@@ -1,9 +1,9 @@
 use std::collections::BTreeMap;
 
-use seaography::async_graphql;
-use seaography::lazy_static;
 use async_graphql::{dynamic::*, Response};
 use sea_orm::{Database, DatabaseConnection};
+use seaography::async_graphql;
+use seaography::lazy_static;
 use seaography::{Builder, BuilderContext, FnGuard, GuardsConfig};
 use seaography_sqlite_example::entities::*;
 

--- a/examples/sqlite/tests/guard_mutation_tests.rs
+++ b/examples/sqlite/tests/guard_mutation_tests.rs
@@ -2,9 +2,7 @@ use std::collections::BTreeMap;
 
 use async_graphql::{dynamic::*, Response};
 use sea_orm::{Database, DatabaseConnection};
-use seaography::async_graphql;
-use seaography::lazy_static;
-use seaography::{Builder, BuilderContext, FnGuard, GuardsConfig};
+use seaography::{async_graphql, lazy_static, Builder, BuilderContext, FnGuard, GuardsConfig};
 use seaography_sqlite_example::entities::*;
 
 lazy_static::lazy_static! {

--- a/examples/sqlite/tests/guard_mutation_tests.rs
+++ b/examples/sqlite/tests/guard_mutation_tests.rs
@@ -1,5 +1,7 @@
 use std::collections::BTreeMap;
 
+use seaography::async_graphql;
+use seaography::lazy_static;
 use async_graphql::{dynamic::*, Response};
 use sea_orm::{Database, DatabaseConnection};
 use seaography::{Builder, BuilderContext, FnGuard, GuardsConfig};

--- a/examples/sqlite/tests/guard_tests.rs
+++ b/examples/sqlite/tests/guard_tests.rs
@@ -1,9 +1,9 @@
 use std::collections::BTreeMap;
 
-use seaography::async_graphql;
-use seaography::lazy_static;
 use async_graphql::{dynamic::*, Response};
 use sea_orm::{Database, DatabaseConnection, RelationTrait};
+use seaography::async_graphql;
+use seaography::lazy_static;
 use seaography::{
     Builder, BuilderContext, EntityObjectRelationBuilder, EntityObjectViaRelationBuilder, FnGuard,
     GuardsConfig,

--- a/examples/sqlite/tests/guard_tests.rs
+++ b/examples/sqlite/tests/guard_tests.rs
@@ -2,11 +2,9 @@ use std::collections::BTreeMap;
 
 use async_graphql::{dynamic::*, Response};
 use sea_orm::{Database, DatabaseConnection, RelationTrait};
-use seaography::async_graphql;
-use seaography::lazy_static;
 use seaography::{
-    Builder, BuilderContext, EntityObjectRelationBuilder, EntityObjectViaRelationBuilder, FnGuard,
-    GuardsConfig,
+    async_graphql, lazy_static, Builder, BuilderContext, EntityObjectRelationBuilder,
+    EntityObjectViaRelationBuilder, FnGuard, GuardsConfig,
 };
 
 lazy_static::lazy_static! {

--- a/examples/sqlite/tests/guard_tests.rs
+++ b/examples/sqlite/tests/guard_tests.rs
@@ -1,5 +1,7 @@
 use std::collections::BTreeMap;
 
+use seaography::async_graphql;
+use seaography::lazy_static;
 use async_graphql::{dynamic::*, Response};
 use sea_orm::{Database, DatabaseConnection, RelationTrait};
 use seaography::{

--- a/examples/sqlite/tests/mutation_tests.rs
+++ b/examples/sqlite/tests/mutation_tests.rs
@@ -1,6 +1,6 @@
-use seaography::async_graphql;
 use async_graphql::{dynamic::*, Response};
 use sea_orm::Database;
+use seaography::async_graphql;
 
 #[tokio::test]
 async fn main() {

--- a/examples/sqlite/tests/mutation_tests.rs
+++ b/examples/sqlite/tests/mutation_tests.rs
@@ -1,3 +1,4 @@
+use seaography::async_graphql;
 use async_graphql::{dynamic::*, Response};
 use sea_orm::Database;
 

--- a/examples/sqlite/tests/query_tests.rs
+++ b/examples/sqlite/tests/query_tests.rs
@@ -1,3 +1,4 @@
+use seaography::async_graphql;
 use async_graphql::{dynamic::*, Response};
 use sea_orm::Database;
 

--- a/examples/sqlite/tests/query_tests.rs
+++ b/examples/sqlite/tests/query_tests.rs
@@ -1,6 +1,6 @@
-use seaography::async_graphql;
 use async_graphql::{dynamic::*, Response};
 use sea_orm::Database;
+use seaography::async_graphql;
 
 pub async fn get_schema() -> Schema {
     let database = Database::connect("sqlite://sakila.db").await.unwrap();

--- a/generator/src/templates/actix.rs
+++ b/generator/src/templates/actix.rs
@@ -11,17 +11,18 @@ pub fn generate_main(crate_name: &str) -> TokenStream {
 
     quote! {
         use actix_web::{guard, web, web::Data, App, HttpResponse, HttpServer, Result};
+        use seaography::async_graphql;
         use async_graphql::{
             dynamic::*,
             http::{playground_source, GraphQLPlaygroundConfig},
         };
         use async_graphql_actix_web::{GraphQLRequest, GraphQLResponse};
         use dotenv::dotenv;
-        use lazy_static::lazy_static;
+        use seaography::lazy_static;
         use sea_orm::Database;
         use std::env;
 
-        lazy_static! {
+        lazy_static::lazy_static! {
             static ref URL: String = env::var("URL").unwrap_or("localhost:8000".into());
             static ref ENDPOINT: String = env::var("ENDPOINT").unwrap_or("/".into());
             static ref DATABASE_URL: String =

--- a/generator/src/templates/actix.rs
+++ b/generator/src/templates/actix.rs
@@ -11,15 +11,14 @@ pub fn generate_main(crate_name: &str) -> TokenStream {
 
     quote! {
         use actix_web::{guard, web, web::Data, App, HttpResponse, HttpServer, Result};
-        use seaography::async_graphql;
         use async_graphql::{
             dynamic::*,
             http::{playground_source, GraphQLPlaygroundConfig},
         };
         use async_graphql_actix_web::{GraphQLRequest, GraphQLResponse};
         use dotenv::dotenv;
-        use seaography::lazy_static;
         use sea_orm::Database;
+        use seaography::{async_graphql, lazy_static};
         use std::env;
 
         lazy_static::lazy_static! {

--- a/generator/src/templates/actix_cargo.toml
+++ b/generator/src/templates/actix_cargo.toml
@@ -6,13 +6,11 @@ version = "0.1.0"
 [dependencies]
 actix-web = { version = "4.5", default-features = false, features = ["macros"] }
 async-graphql-actix-web = { version = "7.0" }
-async-graphql = { version = "7.0", features = ["decimal", "chrono", "dataloader", "dynamic-schema"] }
 dotenv = "0.15.0"
 sea-orm = { version = "~1.1.2", features = ["<seaography-sql-library>", "runtime-async-std-native-tls", "seaography"] }
 tokio = { version = "1.29.1", features = ["macros", "rt-multi-thread"] }
 tracing = { version = "0.1.37" }
 tracing-subscriber = { version = "0.3.17" }
-lazy_static = { version = "1.4.0" }
 
 [dependencies.seaography]
 version = "~<seaography-version>" # seaography version

--- a/generator/src/templates/actix_cargo.toml
+++ b/generator/src/templates/actix_cargo.toml
@@ -7,7 +7,7 @@ version = "0.1.0"
 actix-web = { version = "4.5", default-features = false, features = ["macros"] }
 async-graphql-actix-web = { version = "7.0" }
 dotenv = "0.15.0"
-sea-orm = { version = "~1.1.2", features = ["<seaography-sql-library>", "runtime-async-std-native-tls", "seaography"] }
+sea-orm = { version = "~1.1.4", features = ["<seaography-sql-library>", "runtime-async-std-native-tls", "seaography"] }
 tokio = { version = "1.29.1", features = ["macros", "rt-multi-thread"] }
 tracing = { version = "0.1.37" }
 tracing-subscriber = { version = "0.3.17" }

--- a/generator/src/templates/axum.rs
+++ b/generator/src/templates/axum.rs
@@ -10,6 +10,7 @@ pub fn generate_main(crate_name: &str) -> TokenStream {
     let crate_name_token: TokenStream = crate_name.replace('-', "_").parse().unwrap();
 
     quote! {
+        use seaography::async_graphql;
         use async_graphql::http::{playground_source, GraphQLPlaygroundConfig};
         use async_graphql_axum::GraphQL;
         use axum::{
@@ -18,12 +19,12 @@ pub fn generate_main(crate_name: &str) -> TokenStream {
             Router,
         };
         use dotenv::dotenv;
-        use lazy_static::lazy_static;
+        use seaography::lazy_static;
         use sea_orm::Database;
         use std::env;
         use tokio::net::TcpListener;
 
-        lazy_static! {
+        lazy_static::lazy_static! {
             static ref URL: String = env::var("URL").unwrap_or("localhost:8000".into());
             static ref ENDPOINT: String = env::var("ENDPOINT").unwrap_or("/".into());
             static ref DATABASE_URL: String =

--- a/generator/src/templates/axum.rs
+++ b/generator/src/templates/axum.rs
@@ -10,7 +10,6 @@ pub fn generate_main(crate_name: &str) -> TokenStream {
     let crate_name_token: TokenStream = crate_name.replace('-', "_").parse().unwrap();
 
     quote! {
-        use seaography::async_graphql;
         use async_graphql::http::{playground_source, GraphQLPlaygroundConfig};
         use async_graphql_axum::GraphQL;
         use axum::{
@@ -19,8 +18,8 @@ pub fn generate_main(crate_name: &str) -> TokenStream {
             Router,
         };
         use dotenv::dotenv;
-        use seaography::lazy_static;
         use sea_orm::Database;
+        use seaography::{async_graphql, lazy_static};
         use std::env;
         use tokio::net::TcpListener;
 

--- a/generator/src/templates/axum_cargo.toml
+++ b/generator/src/templates/axum_cargo.toml
@@ -7,7 +7,7 @@ version = "0.1.0"
 axum = { version = "0.7" }
 async-graphql-axum = { version = "7.0" }
 dotenv = "0.15.0"
-sea-orm = { version = "~1.1.2", features = ["<seaography-sql-library>", "runtime-async-std-native-tls", "seaography"] }
+sea-orm = { version = "~1.1.4", features = ["<seaography-sql-library>", "runtime-async-std-native-tls", "seaography"] }
 tokio = { version = "1.29.1", features = ["macros", "rt-multi-thread"] }
 tracing = { version = "0.1.37" }
 tracing-subscriber = { version = "0.3.17" }

--- a/generator/src/templates/axum_cargo.toml
+++ b/generator/src/templates/axum_cargo.toml
@@ -6,13 +6,11 @@ version = "0.1.0"
 [dependencies]
 axum = { version = "0.7" }
 async-graphql-axum = { version = "7.0" }
-async-graphql = { version = "7.0", features = ["decimal", "chrono", "dataloader", "dynamic-schema"] }
 dotenv = "0.15.0"
 sea-orm = { version = "~1.1.2", features = ["<seaography-sql-library>", "runtime-async-std-native-tls", "seaography"] }
 tokio = { version = "1.29.1", features = ["macros", "rt-multi-thread"] }
 tracing = { version = "0.1.37" }
 tracing-subscriber = { version = "0.3.17" }
-lazy_static = { version = "1.4.0" }
 
 [dependencies.seaography]
 version = "~<seaography-version>" # seaography version

--- a/generator/src/templates/poem.rs
+++ b/generator/src/templates/poem.rs
@@ -10,13 +10,12 @@ pub fn generate_main(crate_name: &str) -> TokenStream {
     let crate_name_token: TokenStream = crate_name.replace('-', "_").parse().unwrap();
 
     quote! {
-        use seaography::async_graphql;
         use async_graphql::http::{playground_source, GraphQLPlaygroundConfig};
         use async_graphql_poem::GraphQL;
         use dotenv::dotenv;
-        use seaography::lazy_static;
         use poem::{get, handler, listener::TcpListener, web::Html, IntoResponse, Route, Server};
         use sea_orm::Database;
+        use seaography::{async_graphql, lazy_static};
         use std::env;
 
         lazy_static::lazy_static! {

--- a/generator/src/templates/poem.rs
+++ b/generator/src/templates/poem.rs
@@ -10,15 +10,16 @@ pub fn generate_main(crate_name: &str) -> TokenStream {
     let crate_name_token: TokenStream = crate_name.replace('-', "_").parse().unwrap();
 
     quote! {
+        use seaography::async_graphql;
         use async_graphql::http::{playground_source, GraphQLPlaygroundConfig};
         use async_graphql_poem::GraphQL;
         use dotenv::dotenv;
-        use lazy_static::lazy_static;
+        use seaography::lazy_static;
         use poem::{get, handler, listener::TcpListener, web::Html, IntoResponse, Route, Server};
         use sea_orm::Database;
         use std::env;
 
-        lazy_static! {
+        lazy_static::lazy_static! {
             static ref URL: String = env::var("URL").unwrap_or("localhost:8000".into());
             static ref ENDPOINT: String = env::var("ENDPOINT").unwrap_or("/".into());
             static ref DATABASE_URL: String =

--- a/generator/src/templates/poem_cargo.toml
+++ b/generator/src/templates/poem_cargo.toml
@@ -6,13 +6,11 @@ version = "0.1.0"
 [dependencies]
 poem = { version = "3.0" }
 async-graphql-poem = { version = "7.0" }
-async-graphql = { version = "7.0", features = ["decimal", "chrono", "dataloader", "dynamic-schema"] }
 dotenv = "0.15.0"
 sea-orm = { version = "~1.1.2", features = ["<seaography-sql-library>", "runtime-async-std-native-tls", "seaography"] }
 tokio = { version = "1.29.1", features = ["macros", "rt-multi-thread"] }
 tracing = { version = "0.1.37" }
 tracing-subscriber = { version = "0.3.17" }
-lazy_static = { version = "1.4.0" }
 
 [dependencies.seaography]
 version = "~<seaography-version>" # seaography version

--- a/generator/src/templates/poem_cargo.toml
+++ b/generator/src/templates/poem_cargo.toml
@@ -7,7 +7,7 @@ version = "0.1.0"
 poem = { version = "3.0" }
 async-graphql-poem = { version = "7.0" }
 dotenv = "0.15.0"
-sea-orm = { version = "~1.1.2", features = ["<seaography-sql-library>", "runtime-async-std-native-tls", "seaography"] }
+sea-orm = { version = "~1.1.4", features = ["<seaography-sql-library>", "runtime-async-std-native-tls", "seaography"] }
 tokio = { version = "1.29.1", features = ["macros", "rt-multi-thread"] }
 tracing = { version = "0.1.37" }
 tracing-subscriber = { version = "0.3.17" }

--- a/generator/src/writer.rs
+++ b/generator/src/writer.rs
@@ -83,11 +83,9 @@ pub fn generate_query_root<P: AsRef<Path>>(entities_path: &P) -> TokenStream {
 
     quote! {
         use crate::entities::*;
-        use seaography::async_graphql;
-        use seaography::lazy_static;
         use async_graphql::dynamic::*;
         use sea_orm::DatabaseConnection;
-        use seaography::{Builder, BuilderContext};
+        use seaography::{async_graphql, lazy_static, Builder, BuilderContext};
 
         lazy_static::lazy_static! {
             static ref CONTEXT: BuilderContext = BuilderContext::default();

--- a/generator/src/writer.rs
+++ b/generator/src/writer.rs
@@ -83,6 +83,8 @@ pub fn generate_query_root<P: AsRef<Path>>(entities_path: &P) -> TokenStream {
 
     quote! {
         use crate::entities::*;
+        use seaography::async_graphql;
+        use seaography::lazy_static;
         use async_graphql::dynamic::*;
         use sea_orm::DatabaseConnection;
         use seaography::{Builder, BuilderContext};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -267,3 +267,6 @@ pub use error::*;
 
 pub type SimpleNamingFn = Box<dyn Fn(&str) -> String + Sync + Send>;
 pub type ComplexNamingFn = Box<dyn Fn(&str, &str) -> String + Sync + Send>;
+
+pub use async_graphql;
+pub use lazy_static;


### PR DESCRIPTION
## PR Info

- Dependencies:
  - https://github.com/SeaQL/sea-orm/pull/2469

## New Features

- [x] Re-export `async_graphql` and `lazy_static`
