### PR TITLE
feat: update create_one_mutation and create_batch_mutation to deal with nested create mutation

### DIFF
--- a/src/query/entity_object_relation.rs
+++ b/src/query/entity_object_relation.rs
@@ -1,16 +1,16 @@
 use async_graphql::{
     dataloader::DataLoader,
-    dynamic::{Field, FieldFuture, FieldValue, InputValue, TypeRef},
+    dynamic::{Field, FieldFuture, FieldValue, InputValue, TypeRef, ValueAccessor},
     Error,
 };
 use heck::{ToLowerCamelCase, ToSnakeCase};
-use sea_orm::{EntityTrait, Iden, ModelTrait, RelationDef};
+use sea_orm::{ActiveModelTrait, EntityTrait, Iden, IntoActiveModel, ModelTrait, RelationDef};
 
 use crate::{
-    apply_memory_pagination, get_filter_conditions, BuilderContext, Connection,
-    ConnectionObjectBuilder, EntityObjectBuilder, FilterInputBuilder, GuardAction,
-    HashableGroupKey, KeyComplex, OneToManyLoader, OneToOneLoader, OrderInputBuilder,
-    PaginationInputBuilder,
+    apply_memory_pagination, get_filter_conditions, prepare_active_model, BuilderContext,
+    Connection, ConnectionObjectBuilder, EntityInputBuilder, EntityObjectBuilder,
+    FilterInputBuilder, GuardAction, HashableGroupKey, KeyComplex, OneToManyLoader, OneToOneLoader,
+    OrderInputBuilder, PaginationInputBuilder,
 };
 
 /// This builder produces a GraphQL field for an SeaORM entity relationship
@@ -187,6 +187,96 @@ impl EntityObjectRelationBuilder {
                     &context.entity_query_field.pagination,
                     TypeRef::named(&context.pagination_input.type_name),
                 )),
+        }
+    }
+    pub fn get_mutation_relation<T, R>(
+        &self,
+        name: &str,
+        relation_definition: RelationDef,
+    ) -> InputValue
+    where
+        T: EntityTrait,
+        <T as EntityTrait>::Model: Sync,
+        <<T as sea_orm::EntityTrait>::Column as std::str::FromStr>::Err: core::fmt::Debug,
+        R: EntityTrait,
+        <R as sea_orm::EntityTrait>::Model: Sync,
+        <<R as sea_orm::EntityTrait>::Column as std::str::FromStr>::Err: core::fmt::Debug,
+    {
+        let name = if cfg!(feature = "field-snake-case") {
+            name.to_snake_case()
+        } else {
+            name.to_lower_camel_case()
+        };
+        let context: &'static BuilderContext = self.context;
+
+        let entity_input_builder = EntityInputBuilder { context };
+        let object_insert_input_name = entity_input_builder.insert_type_name::<R>();
+        match (relation_definition.is_owner, relation_definition.rel_type) {
+            (true, sea_orm::RelationType::HasMany) => InputValue::new(
+                name.clone(),
+                TypeRef::named_nn_list(object_insert_input_name),
+            ),
+            _ => InputValue::new(name.clone(), TypeRef::named(object_insert_input_name)),
+        }
+    }
+    pub fn insert_related<T, A, R, B>(
+        &self,
+        relation_definition: RelationDef,
+        input_object: &ValueAccessor<'_>,
+        owner: bool,
+    ) -> async_graphql::Result<Option<Vec<B>>>
+    where
+        T: EntityTrait,
+        R: EntityTrait,
+        <T as EntityTrait>::Model: Sync,
+        <R as sea_orm::EntityTrait>::Model: Sync,
+        <<T as sea_orm::EntityTrait>::Column as std::str::FromStr>::Err: core::fmt::Debug,
+        <<R as sea_orm::EntityTrait>::Column as std::str::FromStr>::Err: core::fmt::Debug,
+        <T as EntityTrait>::Model: IntoActiveModel<A>,
+        A: ActiveModelTrait<Entity = T> + sea_orm::ActiveModelBehavior + std::marker::Send,
+        <R as EntityTrait>::Model: IntoActiveModel<B>,
+        B: ActiveModelTrait<Entity = R> + sea_orm::ActiveModelBehavior + std::marker::Send,
+    {
+        let context = self.context;
+        let entity_object_builder = EntityObjectBuilder { context };
+        let entity_input_builder = EntityInputBuilder { context };
+        if owner == relation_definition.is_owner {
+            Ok(None)
+        } else {
+            match (relation_definition.is_owner, relation_definition.rel_type) {
+                (true, sea_orm::RelationType::HasMany) => {
+                    if let Ok(objs) = input_object.list() {
+                        objs.iter()
+                            .map(|val| {
+                                if let Ok(obj) = val.object() {
+                                    let active_model = prepare_active_model::<R, B>(
+                                        &entity_input_builder,
+                                        &entity_object_builder,
+                                        &obj,
+                                    )?;
+                                    Ok(Some(active_model))
+                                } else {
+                                    Err(async_graphql::Error::new("Invalid Input"))
+                                }
+                            })
+                            .collect()
+                    } else {
+                        Err(async_graphql::Error::new("Invalid Input"))
+                    }
+                }
+                _ => {
+                    if let Ok(obj) = input_object.object() {
+                        let active_model = prepare_active_model::<R, B>(
+                            &entity_input_builder,
+                            &entity_object_builder,
+                            &obj,
+                        )?;
+                        Ok(Some(vec![active_model]))
+                    } else {
+                        Err(async_graphql::Error::new("Invalid Input"))
+                    }
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## PR Info

<!-- mention the related issue -->
- Closes https://github.com/SeaQL/seaography/issues/143

<!-- is this PR depends on other PR? (if applicable) -->
- Dependencies:
  - https://github.com/SeaQL/sea-orm/pull/2493

<!-- any PR depends on this PR? (if applicable) -->
- Dependents:
  - https://github.com/SeaQL/sea-orm/pull/2493

## New Features

- [x] Create an entity and its related entities in a single GraphQL query.
