### PR TITLE
feat: macros for implementing custom mutations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = [".", "cli", "generator"]
+members = [".", "cli", "generator", "gql_macro"]
 
 [package]
 name = "seaography"
@@ -24,6 +24,7 @@ thiserror = { version = "1.0.44" }
 fnv = { version = "1.0.7" }
 lazy_static = { version = "1.5" }
 serde_json = { version = "1.0" }
+serde = { version = "1.0" }
 
 [features]
 default = ["field-camel-case"]

--- a/examples/sqlite/Cargo.toml
+++ b/examples/sqlite/Cargo.toml
@@ -12,6 +12,9 @@ tokio = { version = "1.29.1", features = ["macros", "rt-multi-thread"] }
 tracing = { version = "0.1.37" }
 tracing-subscriber = { version = "0.3.17" }
 
+[dependencies.gql-macro]
+path = "../../gql_macro"
+
 [dependencies.seaography]
 path = "../../"
 version = "~1.1.4" # seaography version

--- a/examples/sqlite/src/query_root.rs
+++ b/examples/sqlite/src/query_root.rs
@@ -1,7 +1,9 @@
 use crate::entities::*;
 use async_graphql::dynamic::*;
-use sea_orm::DatabaseConnection;
-use seaography::{async_graphql, lazy_static, Builder, BuilderContext};
+use async_graphql::Context;
+use sea_orm::{DatabaseConnection, EntityTrait};
+use seaography::{async_graphql, lazy_static, Builder, BuilderContext, impl_gql};
+use gql_macro::mutation;
 
 lazy_static::lazy_static! { static ref CONTEXT : BuilderContext = BuilderContext :: default () ; }
 
@@ -32,10 +34,35 @@ pub fn schema(
             store,
         ]
     );
+
+    builder
+        .mutations
+        .extend((CustomMutations {}).into_dynamic_fields());
+
     builder
         .set_depth_limit(depth)
         .set_complexity_limit(complexity)
         .schema_builder()
         .data(database)
         .finish()
+}
+
+pub struct CustomMutations {}
+
+impl_gql!(customer::Model);
+
+#[mutation]
+impl CustomMutations {
+    async fn foo(&self, _ctx: &Context<'_>, username: String) -> async_graphql::Result<String> {
+        Ok(format!("Hello, {}!", username))
+    }
+
+    async fn bar(&self, _ctx: &Context<'_>, x: i32, y: i32) -> async_graphql::Result<i32> {
+        Ok(x + y)
+    }
+
+    async fn login(&self, ctx: &Context<'_>) -> async_graphql::Result<customer::Model> {
+        let repo = ctx.data::<DatabaseConnection>().unwrap();
+        Ok(customer::Entity::find().one(repo).await?.unwrap())
+    }
 }

--- a/gql_macro/Cargo.toml
+++ b/gql_macro/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "gql-macro"
+version = "0.1.0"
+edition = "2024"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2 = { version = "1" }
+quote = { version = "1" }
+syn = { version = "2", features = ["full"] }
+
+[dev-dependencies]
+async-graphql = { version = "7", features = ["dynamic-schema"] }
+sea-orm = { version = "1" }
+seaography = { path = "../."}
+tokio = { version = "1", features = ["macros", "rt"] }

--- a/gql_macro/README.md
+++ b/gql_macro/README.md
@@ -1,0 +1,79 @@
+# Gql Proc Macro
+
+This crate provides a procedural macro for creating async-graphql dynamic fields from Rust functions.
+
+## Usage
+
+The `#[mutation]` macro transforms an async Rust function into an async-graphql dynamic field. The function must:
+
+1. Be `async`
+2. Have its first parameter be an `async_graphql::dynamic::Context`
+3. Have additional parameters that will become GraphQL arguments
+4. Return a value that can be converted to a GraphQL type
+
+## Example
+
+```rust
+use gql_macro::mutation;
+
+#[mutation]
+async fn login(ctx: async_graphql::dynamic::Context, username: String, password: String) -> String {
+    // Your login logic here
+    format!("Login attempt for user: {}", username)
+}
+
+#[mutation]
+async fn create_user(ctx: async_graphql::dynamic::Context, name: String, email: String, age: i32) -> String {
+    // Your user creation logic here
+    format!("Created user: {} with email: {} and age: {}", name, email, age)
+}
+```
+
+This generates a function that returns an `async_graphql::dynamic::Field`:
+
+```rust
+pub fn login() -> async_graphql::dynamic::Field {
+    async_graphql::dynamic::Field::new(
+        "login",
+        async_graphql::dynamic::TypeRef::named_nn("String"),
+        move |ctx| {
+            use async_graphql::dynamic::{FieldFuture, FieldValue};
+            
+            let username = ctx.args.get("username");
+            let password = ctx.args.get("password");
+            
+            FieldFuture::new(async move {
+                let result = login(ctx).await;
+                Ok(Some(FieldValue::owned_any(result)))
+            })
+        },
+    )
+    .argument(async_graphql::dynamic::InputValue::new(
+        "username",
+        async_graphql::dynamic::TypeRef::named_nn("String"),
+    ))
+    .argument(async_graphql::dynamic::InputValue::new(
+        "password",
+        async_graphql::dynamic::TypeRef::named_nn("String"),
+    ))
+}
+```
+
+## Supported Types
+
+The macro automatically maps Rust types to GraphQL types:
+
+- `String` → `String`
+- `&str` → `String`
+- `i32` → `Int`
+- `f64` → `Float`
+- `bool` → `Boolean`
+
+Other types default to `String`.
+
+## Requirements
+
+- Function must be `async`
+- First parameter must be `async_graphql::dynamic::Context`
+- All parameters must be simple identifiers (no destructuring)
+- Function cannot have `self` parameter 

--- a/gql_macro/src/lib.rs
+++ b/gql_macro/src/lib.rs
@@ -1,0 +1,103 @@
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{parse_macro_input, parse_quote, FnArg, ImplItem, ItemImpl, Pat, ReturnType, Type};
+
+#[proc_macro_attribute]
+pub fn mutation(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    let mut impl_block = parse_macro_input!(item as ItemImpl);
+
+    let mut fields = Vec::new();
+
+    for item in &mut impl_block.items {
+        if let ImplItem::Fn(fn_item) = item {
+            let fn_ident = &fn_item.sig.ident;
+            let fn_name = fn_item.sig.ident.to_string();
+            let return_ty = &fn_item.sig.output;
+
+            let new_field_return_ty = match return_ty {
+                ReturnType::Type(_, ty) => {
+                    if let Type::Path(type_path) = ty.as_ref() {
+                        quote! { <#type_path as seaography::GqlTypeRef>::gql_type_ref() }
+                    } else {
+                        panic!("No return type path found");
+                    }
+                }
+                _ => panic!("Ambiguous return type"),
+            };
+
+            let new_field_args = fn_item
+                .sig
+                .inputs
+                .iter()
+                .skip(2)
+                .map(|arg| match arg {
+                    FnArg::Typed(pat_type) => {
+                        let arg_name = match &*pat_type.pat {
+                            Pat::Ident(pat_ident) => pat_ident.ident.to_string(),
+                            _ => panic!("Expected identifier pattern"),
+                        };
+                        if let Type::Path(type_path) = pat_type.ty.as_ref() {
+                            quote! { .argument(async_graphql::dynamic::InputValue::new(#arg_name, <#type_path as seaography::GqlTypeRef>::gql_type_ref())) }
+                        } else {
+                            panic!("No argument type path found: {:?}", pat_type.ty)
+                        }
+                    }
+                    FnArg::Receiver(_) => panic!("Receiver must be the first argument"),
+                });
+
+            let new_resolver_args = fn_item
+                .sig
+                .inputs
+                .iter()
+                .skip(2)
+                .map(|arg| match arg {
+                    FnArg::Typed(pat_type) => {
+                        let arg_name = match &*pat_type.pat {
+                            Pat::Ident(pat_ident) => pat_ident.ident.to_string(),
+                            _ => panic!("Expected identifier pattern"),
+                        };
+                        if let Type::Path(type_path) = pat_type.ty.as_ref() {
+                            quote! { ctx.args.get(#arg_name).map(|v| v.deserialize::<#type_path>()).unwrap_or(Err(async_graphql::Error::new(format!("{} is required", #arg_name))))?  }
+                        } else {
+                            panic!("No argument type path found: {:?}", pat_type.ty)
+                        }
+                    }
+                    FnArg::Receiver(_) => panic!("Receiver must be the first argument"),
+                });
+
+            let new_field = quote! {
+                fields.push({
+                    let this = this.clone();
+                    async_graphql::dynamic::Field::new(
+                        #fn_name,
+                        #new_field_return_ty,
+                        move |ctx| {
+                            let this = this.clone();
+                            async_graphql::dynamic::FieldFuture::new(async move {
+                                use seaography::GqlFieldValue;
+                                this.as_ref().#fn_ident(&ctx.ctx, #(#new_resolver_args,)*).await.map(|x| Some(x.gql_field_value()))
+                            })
+                        },
+                    )
+                    #(#new_field_args)*
+                });
+            };
+            fields.push(new_field);
+        }
+    }
+
+    let impl_item_dynamic_fields: ImplItem = parse_quote! {
+        pub fn into_dynamic_fields(self) -> std::vec::Vec<async_graphql::dynamic::Field> {
+            let this = std::sync::Arc::new(self);
+            let mut fields = std::vec::Vec::new();
+            #(#fields)*
+            fields
+        }
+    };
+
+    impl_block.items.push(impl_item_dynamic_fields);
+
+    TokenStream::from(quote! {
+        #impl_block
+    })
+}

--- a/gql_macro/tests/mutation.rs
+++ b/gql_macro/tests/mutation.rs
@@ -1,0 +1,74 @@
+use async_graphql::Context;
+use sea_orm::{DatabaseConnection, DeriveEntityModel, entity::prelude::*};
+use seaography::{Builder, BuilderContext, EntityObjectBuilder, lazy_static, impl_gql};
+use gql_macro::mutation;
+
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel, Eq)]
+#[sea_orm(table_name = "users")]
+pub struct Model {
+    #[sea_orm(primary_key)]
+    pub id: i32,
+    pub name: String,
+    pub email: String,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {}
+
+impl ActiveModelBehavior for ActiveModel {}
+
+impl_gql!(Model where context: &CONTEXT);
+
+pub struct TestMutation;
+
+#[mutation]
+impl TestMutation {
+    async fn foo(&self, _ctx: &Context<'_>, username: String) -> async_graphql::Result<String> {
+        Ok(format!("Hello, {}!", username))
+    }
+
+    async fn bar(&self, _ctx: &Context<'_>, x: i32, y: i32) -> async_graphql::Result<i32> {
+        Ok(x + y)
+    }
+
+    async fn baz(&self, _ctx: &Context<'_>) -> async_graphql::Result<Model> {
+        Ok(Model {
+            id: 1,
+            name: "John".to_string(),
+            email: "john@example.com".to_string(),
+        })
+    }
+}
+
+lazy_static::lazy_static! { static ref CONTEXT: BuilderContext = BuilderContext::default (); }
+
+#[tokio::test]
+async fn test_mutations() {
+    let mut builder = Builder::new(&CONTEXT, DatabaseConnection::Disconnected);
+
+    let entity_object_builder = EntityObjectBuilder { context: &CONTEXT };
+
+    builder
+        .outputs
+        .push(entity_object_builder.to_object::<Entity>());
+
+    builder.mutations.extend(TestMutation.into_dynamic_fields());
+
+    let schema_builder = builder.schema_builder();
+
+    let schema = schema_builder.finish().unwrap();
+
+    let query = r#"
+    mutation {
+        baz {
+            id
+            name
+            email
+        }
+    }
+    "#;
+
+    let res = schema.execute(query).await;
+
+    println!("{:#?}", res);
+}

--- a/src/builder_context/filter_types_map.rs
+++ b/src/builder_context/filter_types_map.rs
@@ -30,6 +30,8 @@ pub struct FilterTypesMapConfig {
     pub boolean_filter_info: FilterInfo,
     // basic id filter
     pub id_filter_info: FilterInfo,
+    // basic id filter
+    pub json_filter_info: FilterInfo,
 }
 
 impl std::default::Default for FilterTypesMapConfig {
@@ -148,6 +150,24 @@ impl std::default::Default for FilterTypesMapConfig {
                     FilterOperation::NotBetween,
                 ]),
             },
+            json_filter_info: FilterInfo {
+                type_name: "JsonFilterInput".into(),
+                base_type: "JSON".into(),
+                supported_operations: BTreeSet::from([
+                    FilterOperation::Equals,
+                    FilterOperation::NotEquals,
+                    FilterOperation::GreaterThan,
+                    FilterOperation::GreaterThanEquals,
+                    FilterOperation::LessThan,
+                    FilterOperation::LessThanEquals,
+                    FilterOperation::IsIn,
+                    FilterOperation::IsNotIn,
+                    FilterOperation::IsNull,
+                    FilterOperation::IsNotNull,
+                    FilterOperation::Between,
+                    FilterOperation::NotBetween,
+                ]),
+            },
         }
     }
 }
@@ -215,7 +235,7 @@ impl FilterTypesMapHelper {
             ColumnType::Blob => None,
             ColumnType::Boolean => Some(FilterType::Boolean),
             ColumnType::Money(_) => Some(FilterType::Text),
-            ColumnType::Json => None,
+            ColumnType::Json => Some(FilterType::Json),
             ColumnType::JsonBinary => None,
             ColumnType::Uuid => Some(FilterType::Text),
             ColumnType::Custom(name) => Some(FilterType::Custom(name.to_string())),
@@ -282,6 +302,13 @@ impl FilterTypesMapHelper {
                 }
                 FilterType::Id => {
                     let info = &self.context.filter_types.id_filter_info;
+                    Some(InputValue::new(
+                        column_name,
+                        TypeRef::named(info.type_name.clone()),
+                    ))
+                }
+                FilterType::Json => {
+                    let info = &self.context.filter_types.json_filter_info;
                     Some(InputValue::new(
                         column_name,
                         TypeRef::named(info.type_name.clone()),
@@ -411,6 +438,7 @@ impl FilterTypesMapHelper {
                 FilterType::Float => &self.context.filter_types.float_filter_info,
                 FilterType::Boolean => &self.context.filter_types.boolean_filter_info,
                 FilterType::Id => &self.context.filter_types.id_filter_info,
+                FilterType::Json => &self.context.filter_types.json_filter_info,
                 FilterType::Enumeration(_) => {
                     return prepare_enumeration_condition::<T>(filter, column, condition)
                 }
@@ -618,6 +646,7 @@ pub enum FilterType {
     Float,
     Boolean,
     Id,
+    Json,
     Enumeration(String),
     Custom(String),
 }

--- a/src/inputs/cursor_input.rs
+++ b/src/inputs/cursor_input.rs
@@ -1,9 +1,10 @@
 use async_graphql::dynamic::{InputObject, InputValue, ObjectAccessor, TypeRef};
+use serde::{Deserialize, Serialize};
 
 use crate::BuilderContext;
 
 /// used to hold information about cursor pagination
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub struct CursorInput {
     pub cursor: Option<String>,
     pub limit: u64,

--- a/src/inputs/offset_input.rs
+++ b/src/inputs/offset_input.rs
@@ -1,9 +1,10 @@
 use async_graphql::dynamic::{InputObject, InputValue, ObjectAccessor, TypeRef};
+use serde::{Deserialize, Serialize};
 
 use crate::BuilderContext;
 
 /// used to hold information about offset pagination
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub struct OffsetInput {
     pub offset: u64,
     pub limit: u64,

--- a/src/inputs/page_input.rs
+++ b/src/inputs/page_input.rs
@@ -1,9 +1,10 @@
 use async_graphql::dynamic::{InputObject, InputValue, ObjectAccessor, TypeRef};
+use serde::{Deserialize, Serialize};
 
 use crate::BuilderContext;
 
 /// used to hold information about page pagination
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub struct PageInput {
     pub page: u64,
     pub limit: u64,

--- a/src/inputs/pagination_input.rs
+++ b/src/inputs/pagination_input.rs
@@ -1,4 +1,5 @@
 use async_graphql::dynamic::{InputObject, InputValue, TypeRef, ValueAccessor};
+use serde::{Deserialize, Serialize};
 
 use crate::{BuilderContext, CursorInputBuilder, OffsetInputBuilder, PageInputBuilder};
 
@@ -6,7 +7,7 @@ use super::{CursorInput, OffsetInput, PageInput};
 
 /// used to hold information about which pagination
 /// strategy will be applied on the query
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub struct PaginationInput {
     pub cursor: Option<CursorInput>,
     pub page: Option<PageInput>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -260,6 +260,9 @@ pub use builder::*;
 pub mod error;
 pub use error::*;
 
+pub mod weave;
+pub use weave::*;
+
 pub type SimpleNamingFn = Box<dyn Fn(&str) -> String + Sync + Send>;
 pub type ComplexNamingFn = Box<dyn Fn(&str, &str) -> String + Sync + Send>;
 

--- a/src/mutation/entity_create_one_mutation.rs
+++ b/src/mutation/entity_create_one_mutation.rs
@@ -73,6 +73,7 @@ impl EntityCreateOneMutationBuilder {
 
         let object_name: String = entity_object_builder.type_name::<T>();
         let guard = self.context.guards.entity_guards.get(&object_name);
+        let create_guard = self.context.guards.entity_guards.get(&format!("{}:create", object_name));
         let field_guards = &self.context.guards.field_guards;
 
         Field::new(
@@ -96,10 +97,27 @@ impl EntityCreateOneMutationBuilder {
                             ),
                         };
                     }
+                    let create_guard_flag = if let Some(guard) = create_guard {
+                        (*guard)(&ctx)
+                    } else {
+                        GuardAction::Allow
+                    };
+
+                    if let GuardAction::Block(reason) = create_guard_flag {
+                        return match reason {
+                            Some(reason) => Err::<Option<_>, async_graphql::Error>(
+                                async_graphql::Error::new(reason),
+                            ),
+                            None => Err::<Option<_>, async_graphql::Error>(
+                                async_graphql::Error::new("Entity guard triggered."),
+                            ),
+                        };
+                    }
 
                     let entity_input_builder = EntityInputBuilder { context };
                     let entity_object_builder = EntityObjectBuilder { context };
                     let db = ctx.data::<DatabaseConnection>()?;
+
                     let value_accessor = ctx
                         .args
                         .get(&context.entity_create_one_mutation.data_field)

--- a/src/weave.rs
+++ b/src/weave.rs
@@ -1,0 +1,384 @@
+//! # Weave Core - GraphQL Type System Support
+//!
+//! This crate provides traits and macros for implementing GraphQL type system support
+//! for both scalar types and custom model types. It includes support for nullable
+//! (Option<T>) variants of all types.
+//!
+//! ## Core Traits
+//!
+//! - `GqlFieldValue<'a>`: Convert values to GraphQL field values
+//! - `GqlTypeRef`: Generate GraphQL type references
+//!
+//! ## Scalar Type Support
+//!
+//! All standard scalar types are supported out of the box:
+//! - `bool` and `Option<bool>`
+//! - Integer types: `i8`, `i16`, `i32`, `i64`, `u8`, `u16`, `u32`, `u64` and their `Option<>` variants
+//! - Float types: `f32`, `f64` and their `Option<>` variants
+//! - `String` and `Option<String>`
+//!
+//! ## Custom Model Type Support
+//!
+//! Use the provided macros to implement GraphQL support for your custom types:
+//!
+//! ```rust,ignore
+//! use seaography::impl_gql;
+//!
+//! // Basic implementation for a model
+//! impl_gql!(MyModel);
+//!
+//! // If you need Option<MyModel> support, add this separately:
+//! // impl_gql_field_value_option!(MyModel);
+//! // impl_gql_type_ref_option!(MyModel);
+//! ```
+//!
+//! ## Orphan Rule Compliance
+//!
+//! Due to Rust's orphan rules, Option<T> implementations for external types
+//! must be implemented separately using the `*_option` macros. This prevents
+//! compilation errors when working with types from other crates.
+
+use async_graphql::{
+    dynamic::{FieldValue, TypeRef},
+    Value,
+};
+
+// Add support for seaography Connection types - import is handled in impl blocks
+
+/// A trait for values that can be used as GraphQL field values.
+pub trait GqlFieldValue<'a> {
+    fn gql_field_value(self) -> FieldValue<'a>;
+}
+
+macro_rules! gql_scalar_field_value {
+    ($type:ty) => {
+        impl<'a> GqlFieldValue<'a> for $type {
+            fn gql_field_value(self) -> FieldValue<'a> {
+                FieldValue::value(Value::from(self))
+            }
+        }
+    };
+}
+
+gql_scalar_field_value!(bool);
+gql_scalar_field_value!(i8);
+gql_scalar_field_value!(i16);
+gql_scalar_field_value!(i32);
+gql_scalar_field_value!(i64);
+gql_scalar_field_value!(u8);
+gql_scalar_field_value!(u16);
+gql_scalar_field_value!(u32);
+gql_scalar_field_value!(u64);
+gql_scalar_field_value!(f32);
+gql_scalar_field_value!(f64);
+gql_scalar_field_value!(String);
+
+// Implement GqlFieldValue for Option<> of scalar types
+macro_rules! gql_scalar_field_value_option {
+    ($type:ty) => {
+        impl<'a> GqlFieldValue<'a> for Option<$type> {
+            fn gql_field_value(self) -> FieldValue<'a> {
+                match self {
+                    Some(value) => FieldValue::value(Value::from(value)),
+                    None => FieldValue::value(Value::Null),
+                }
+            }
+        }
+    };
+}
+
+gql_scalar_field_value_option!(bool);
+gql_scalar_field_value_option!(i8);
+gql_scalar_field_value_option!(i16);
+gql_scalar_field_value_option!(i32);
+gql_scalar_field_value_option!(i64);
+gql_scalar_field_value_option!(u8);
+gql_scalar_field_value_option!(u16);
+gql_scalar_field_value_option!(u32);
+gql_scalar_field_value_option!(u64);
+gql_scalar_field_value_option!(f32);
+gql_scalar_field_value_option!(f64);
+gql_scalar_field_value_option!(String);
+
+/// A trait for types that can be used as GraphQL types.
+pub trait GqlTypeRef {
+    fn gql_type_ref() -> TypeRef;
+}
+
+impl<T> GqlTypeRef for async_graphql::Result<T>
+where
+    T: GqlTypeRef,
+{
+    fn gql_type_ref() -> TypeRef {
+        T::gql_type_ref()
+    }
+}
+
+macro_rules! gql_scalar_type_ref {
+    ($type:ty, $e:expr) => {
+        impl GqlTypeRef for Option<$type> {
+            fn gql_type_ref() -> TypeRef {
+                TypeRef::named($e)
+            }
+        }
+
+        impl GqlTypeRef for $type {
+            fn gql_type_ref() -> TypeRef {
+                TypeRef::named_nn($e)
+            }
+        }
+    };
+}
+
+gql_scalar_type_ref!(bool, TypeRef::BOOLEAN);
+gql_scalar_type_ref!(i8, TypeRef::INT);
+gql_scalar_type_ref!(i16, TypeRef::INT);
+gql_scalar_type_ref!(i32, TypeRef::INT);
+gql_scalar_type_ref!(i64, TypeRef::INT);
+gql_scalar_type_ref!(u8, TypeRef::INT);
+gql_scalar_type_ref!(u16, TypeRef::INT);
+gql_scalar_type_ref!(u32, TypeRef::INT);
+gql_scalar_type_ref!(u64, TypeRef::INT);
+gql_scalar_type_ref!(f32, TypeRef::FLOAT);
+gql_scalar_type_ref!(f64, TypeRef::FLOAT);
+gql_scalar_type_ref!(String, TypeRef::STRING);
+
+#[macro_export]
+macro_rules! impl_gql_field_value {
+    ($model:ty) => {
+        impl<'a> seaography::GqlFieldValue<'a> for $model {
+            fn gql_field_value(self) -> async_graphql::dynamic::FieldValue<'a> {
+                async_graphql::dynamic::FieldValue::owned_any(self)
+            }
+        }
+    };
+}
+
+/// Implements `GqlFieldValue` for `Option<T>` where `T` is a custom model type.
+/// This is a separate macro to avoid orphan rule issues.
+///
+/// # Example
+/// ```rust,ignore
+/// use seaography::impl_gql_field_value_option;
+///
+/// // For a custom model type
+/// impl_gql_field_value_option!(MyModel);
+/// ```
+#[macro_export]
+macro_rules! impl_gql_field_value_option {
+    ($model:ty) => {
+        impl<'a> seaography::GqlFieldValue<'a> for Option<$model> {
+            fn gql_field_value(self) -> async_graphql::dynamic::FieldValue<'a> {
+                match self {
+                    Some(value) => async_graphql::dynamic::FieldValue::owned_any(value),
+                    None => async_graphql::dynamic::FieldValue::value(async_graphql::Value::Null),
+                }
+            }
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! impl_gql_type_ref {
+    ($model:ty) => {
+        seaography::impl_gql_type_ref!($model where context: &CONTEXT);
+    };
+    ($model:ty where context: $context:expr) => {
+        impl seaography::GqlTypeRef for $model {
+            fn gql_type_ref() -> async_graphql::dynamic::TypeRef {
+                async_graphql::dynamic::TypeRef::named_nn(
+                    seaography::EntityObjectBuilder { context: $context }.type_name::<<Self as sea_orm::ModelTrait>::Entity>(),
+                )
+            }
+        }
+    };
+}
+
+/// Implements `GqlTypeRef` for `Option<T>` where `T` is a custom model type.
+/// This creates a nullable GraphQL type reference.
+///
+/// # Example
+/// ```rust,ignore
+/// use seaography::impl_gql_type_ref_option;
+///
+/// // For a custom model type with default context
+/// impl_gql_type_ref_option!(MyModel);
+///
+/// // For a custom model type with specific context
+/// impl_gql_type_ref_option!(MyModel where context: &my_context);
+/// ```
+#[macro_export]
+macro_rules! impl_gql_type_ref_option {
+    ($model:ty) => {
+        seaography::impl_gql_type_ref_option!($model where context: &CONTEXT);
+    };
+    ($model:ty where context: $context:expr) => {
+        impl seaography::GqlTypeRef for Option<$model> {
+            fn gql_type_ref() -> async_graphql::dynamic::TypeRef {
+                async_graphql::dynamic::TypeRef::named(
+                    crate::EntityObjectBuilder { context: $context }.type_name::<<$model as sea_orm::ModelTrait>::Entity>(),
+                )
+            }
+        }
+    };
+}
+
+/// Implements both `GqlFieldValue` and `GqlTypeRef` for a model type.
+/// This is a convenience macro that combines the two implementations.
+///
+/// Note: This does NOT automatically implement the Option<> versions to avoid orphan rule issues.
+/// If you need Option<> support, use the separate macros:
+/// - `impl_gql_field_value_option!`
+/// - `impl_gql_type_ref_option!`
+///
+/// # Example
+/// ```rust,ignore
+/// use seaography::impl_gql;
+///
+/// // Basic usage with default context
+/// impl_gql!(MyModel);
+///
+/// // With specific context
+/// impl_gql!(MyModel where context: &my_context);
+///
+/// // If you also need Option<> support, add these:
+/// // impl_gql_field_value_option!(MyModel);
+/// // impl_gql_type_ref_option!(MyModel);
+/// ```
+#[macro_export]
+macro_rules! impl_gql {
+    ($model:ty) => {
+        seaography::impl_gql!($model where context: &CONTEXT);
+    };
+    ($model:ty where context: $context:expr) => {
+        seaography::impl_gql_field_value!($model);
+        seaography::impl_gql_type_ref!($model where context: $context);
+    };
+}
+
+// Connection support for seaography
+impl<'a, T> GqlFieldValue<'a> for crate::Connection<T>
+where
+    T: sea_orm::EntityTrait + 'static,
+    T::Model: Sync,
+{
+    fn gql_field_value(self) -> FieldValue<'a> {
+        FieldValue::owned_any(self)
+    }
+}
+
+impl GqlTypeRef for Option<crate::PaginationInput> {
+    fn gql_type_ref() -> TypeRef {
+        TypeRef::named("PaginationInput".to_string())
+    }
+}
+
+impl<T> GqlTypeRef for crate::Connection<T>
+where
+    T: sea_orm::EntityTrait + 'static,
+    T::Model: Sync,
+{
+    // FIXME: pretty sure this doenst work
+    fn gql_type_ref() -> TypeRef {
+        // Generate the connection type name based on the entity name
+        let entity_name = std::any::type_name::<T>()
+            .split("::")
+            .last()
+            .unwrap_or("Unknown")
+            .replace("Entity", "");
+        TypeRef::named_nn(format!("{}Connection", entity_name))
+        //TypeRef::named_nn("Connection")
+    }
+}
+
+/// Implements both `GqlFieldValue` and `GqlTypeRef` for seaography Connection types.
+/// This is a convenience macro for Connection<T> where T is a SeaORM entity.
+///
+/// # Example
+/// ```rust,ignore
+/// use seaography::impl_gql_connection;
+/// use my_entities::modules;
+///
+/// // Implement GraphQL support for Connection<modules::Entity>
+/// impl_gql_connection!(modules::Entity);
+/// ```
+#[macro_export]
+macro_rules! impl_gql_connection {
+    ($entity:ty) => {
+        // Connection types are already implemented generically above
+        // This macro is provided for consistency and future extensibility
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_scalar_option_field_values() {
+        // Test that the methods exist and can be called without errors
+        // We can't easily test the internal structure of FieldValue without
+        // accessing private implementation details
+
+        // Test Option<bool>
+        let some_bool: Option<bool> = Some(true);
+        let none_bool: Option<bool> = None;
+        let _field_value1 = some_bool.gql_field_value();
+        let _field_value2 = none_bool.gql_field_value();
+
+        // Test Option<i32>
+        let some_int: Option<i32> = Some(42);
+        let none_int: Option<i32> = None;
+        let _field_value3 = some_int.gql_field_value();
+        let _field_value4 = none_int.gql_field_value();
+
+        // Test Option<String>
+        let some_string: Option<String> = Some("hello".to_string());
+        let none_string: Option<String> = None;
+        let _field_value5 = some_string.gql_field_value();
+        let _field_value6 = none_string.gql_field_value();
+
+        // Test Option<f64>
+        let some_float: Option<f64> = Some(3.14);
+        let none_float: Option<f64> = None;
+        let _field_value7 = some_float.gql_field_value();
+        let _field_value8 = none_float.gql_field_value();
+    }
+
+    #[test]
+    fn test_scalar_type_refs() {
+        // Test non-nullable types
+        assert_eq!(bool::gql_type_ref(), TypeRef::named_nn(TypeRef::BOOLEAN));
+        assert_eq!(i32::gql_type_ref(), TypeRef::named_nn(TypeRef::INT));
+        assert_eq!(f64::gql_type_ref(), TypeRef::named_nn(TypeRef::FLOAT));
+        assert_eq!(String::gql_type_ref(), TypeRef::named_nn(TypeRef::STRING));
+
+        // Test nullable types
+        assert_eq!(
+            Option::<bool>::gql_type_ref(),
+            TypeRef::named(TypeRef::BOOLEAN)
+        );
+        assert_eq!(Option::<i32>::gql_type_ref(), TypeRef::named(TypeRef::INT));
+        assert_eq!(
+            Option::<f64>::gql_type_ref(),
+            TypeRef::named(TypeRef::FLOAT)
+        );
+        assert_eq!(
+            Option::<String>::gql_type_ref(),
+            TypeRef::named(TypeRef::STRING)
+        );
+    }
+
+    #[test]
+    fn test_result_type_ref() {
+        // Test that async_graphql::Result<T> uses T's type ref
+        assert_eq!(
+            async_graphql::Result::<bool>::gql_type_ref(),
+            TypeRef::named_nn(TypeRef::BOOLEAN)
+        );
+        assert_eq!(
+            async_graphql::Result::<Option<i32>>::gql_type_ref(),
+            TypeRef::named(TypeRef::INT)
+        );
+    }
+}


### PR DESCRIPTION
This PR adds a technique for easily registering custom mutations via macros.

## New Features

- [ ] Derive gql schema via macro_rules
- [ ] Serde support on connection types

## Changes

- [ ] Beginnings of JSON filter support - but this isn't currently working
