### PR TITLE
fix: also register basic object

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -144,6 +144,9 @@ impl Builder {
         let entity_object = entity_object_builder.to_object::<T>();
         self.outputs.push(entity_object);
 
+        let basic_entity_object = entity_object_builder.to_basic_object::<T>();
+        self.outputs.push(basic_entity_object);
+
         let entity_input_builder = EntityInputBuilder {
             context: self.context,
         };


### PR DESCRIPTION
## PR Info

Currently, register_basic_entity doesn't register the basic_object; preventing us from using basic entities as return types. This PR fixes that


## Bug Fixes

- [ ] Register basic object when calling `register_basic_entity`
