### PR TITLE
fix: Compile errors with uuid feature

### DIFF
--- a/src/builder_context/types_map.rs
+++ b/src/builder_context/types_map.rs
@@ -666,8 +666,6 @@ pub fn converted_value_to_sea_orm_value(
         }
         #[cfg(feature = "with-time")]
         ConvertedType::TimeDate => {
-            use std::str::FromStr;
-
             let value = sea_orm::entity::prelude::TimeDate::parse(
                 value.string()?,
                 sea_orm::sea_query::value::time_format::FORMAT_DATE,
@@ -683,8 +681,6 @@ pub fn converted_value_to_sea_orm_value(
         }
         #[cfg(feature = "with-time")]
         ConvertedType::TimeTime => {
-            use std::str::FromStr;
-
             let value = sea_orm::entity::prelude::TimeTime::parse(
                 value.string()?,
                 sea_orm::sea_query::value::time_format::FORMAT_TIME,
@@ -700,8 +696,6 @@ pub fn converted_value_to_sea_orm_value(
         }
         #[cfg(feature = "with-time")]
         ConvertedType::TimeDateTime => {
-            use std::str::FromStr;
-
             let value = sea_orm::entity::prelude::TimeDateTime::parse(
                 value.string()?,
                 sea_orm::sea_query::value::time_format::FORMAT_DATETIME,
@@ -717,7 +711,6 @@ pub fn converted_value_to_sea_orm_value(
         }
         #[cfg(feature = "with-time")]
         ConvertedType::TimeDateTimeWithTimeZone => {
-            use std::str::FromStr;
             let value = sea_orm::entity::prelude::TimeDateTimeWithTimeZone::parse(
                 value.string()?,
                 sea_orm::sea_query::value::time_format::FORMAT_DATETIME_TZ,

--- a/src/outputs/entity_object.rs
+++ b/src/outputs/entity_object.rs
@@ -369,6 +369,6 @@ fn sea_query_value_to_graphql_value(
         // #[cfg(feature = "with-mac_address")]
         // #[cfg_attr(docsrs, doc(cfg(feature = "with-mac_address")))]
         // sea_orm::sea_query::Value::MacAddress(value) => value.map(|it| Value::from(it.to_string())),
-        _ => None,
+        // _ => None,
     }
 }

--- a/src/utilities.rs
+++ b/src/utilities.rs
@@ -248,9 +248,9 @@ pub fn decode_cursor(s: &str) -> Result<Vec<sea_orm::Value>, sea_orm::DbErr> {
                                 sea_orm::Value::Uuid(None)
                             } else {
                                 sea_orm::Value::Uuid(Some(Box::new(
-                                    data_buffer
-                                        .parse::<sea_orm::prelude::Uuid>()
-                                        .map_err(parse_int_err)?,
+                                    data_buffer.parse::<sea_orm::prelude::Uuid>().map_err(|e| {
+                                        sea_orm::DbErr::Type(format!("Failed to parse UUID: {e}"))
+                                    })?,
                                 )))
                             }
                         }


### PR DESCRIPTION
Fixes the following errors with `cargo build --all-features`:

```
   Compiling seaography v1.1.4 (/Users/peter/q/seaography)
warning: unused import: `std::str::FromStr`
   --> src/builder_context/types_map.rs:669:17
    |
669 |             use std::str::FromStr;
    |                 ^^^^^^^^^^^^^^^^^
    |
    = note: `#[warn(unused_imports)]` on by default

warning: unused import: `std::str::FromStr`
   --> src/builder_context/types_map.rs:686:17
    |
686 |             use std::str::FromStr;
    |                 ^^^^^^^^^^^^^^^^^

warning: unused import: `std::str::FromStr`
   --> src/builder_context/types_map.rs:703:17
    |
703 |             use std::str::FromStr;
    |                 ^^^^^^^^^^^^^^^^^

warning: unused import: `std::str::FromStr`
   --> src/builder_context/types_map.rs:720:17
    |
720 |             use std::str::FromStr;
    |                 ^^^^^^^^^^^^^^^^^

error[E0631]: type mismatch in function arguments
   --> src/utilities.rs:253:50
    |
253 |                                         .map_err(parse_int_err)?,
    |                                          ------- ^^^^^^^^^^^^^ expected due to this
    |                                          |
    |                                          required by a bound introduced by this call
...
303 | fn parse_int_err(err: std::num::ParseIntError) -> sea_orm::DbErr {
    | ---------------------------------------------------------------- found signature defined here
    |
    = note: expected function signature `fn(uuid::error::Error) -> _`
               found function signature `fn(ParseIntError) -> _`
note: required by a bound in `Result::<T, E>::map_err`
   --> /rustc/29483883eed69d5fb4db01964cdf2af4d86e9cb2/library/core/src/result.rs:911:5
help: consider wrapping the function in a closure
    |
253 |                                         .map_err(|arg0: uuid::error::Error| parse_int_err(/* ParseIntError */))?,
    |                                                  ++++++++++++++++++++++++++              +++++++++++++++++++++

warning: unreachable pattern
   --> src/outputs/entity_object.rs:372:9
    |
372 |         _ => None,
    |         ^ no value can reach this
    |
note: multiple earlier patterns match some of the same values
   --> src/outputs/entity_object.rs:372:9
    |
267 |         sea_orm::Value::Bool(value) => value.map(Value::from),
    |         --------------------------- matches some of the same values
268 |         sea_orm::Value::TinyInt(value) => value.map(Value::from),
    |         ------------------------------ matches some of the same values
269 |         sea_orm::Value::SmallInt(value) => value.map(Value::from),
    |         ------------------------------- matches some of the same values
270 |         sea_orm::Value::Int(value) => value.map(Value::from),
    |         -------------------------- matches some of the same values
...
372 |         _ => None,
    |         ^ ...and 25 other patterns collectively make this unreachable
    = note: `#[warn(unreachable_patterns)]` on by default

For more information about this error, try `rustc --explain E0631`.
warning: `seaography` (lib) generated 5 warnings
error: could not compile `seaography` (lib) due to 1 previous error; 5 warnings emitted
```