### PR TITLE
fix: Handle downcast_ref in Option case

### DIFF
--- a/src/builder_context/filter_types_map.rs
+++ b/src/builder_context/filter_types_map.rs
@@ -361,10 +361,10 @@ impl FilterTypesMapHelper {
                         FilterType::Integer => &self.context.filter_types.integer_array_filter_info,
                         FilterType::Float => &self.context.filter_types.float_array_filter_info,
                         FilterType::Boolean => &self.context.filter_types.boolean_array_filter_info,
-                        FilterType::Id => todo!(),
-                        FilterType::Enumeration(_) => todo!(),
-                        FilterType::Custom(_) => todo!(),
-                        FilterType::Array(_) => todo!(),
+                        FilterType::Id => return None, // todo!(),
+                        FilterType::Enumeration(_) => return None, // todo!(),
+                        FilterType::Custom(_) => return None, // todo!(),
+                        FilterType::Array(_) => return None, // todo!(),
                     };
                     Some(InputValue::new(
                         column_name,

--- a/src/builder_context/types_map.rs
+++ b/src/builder_context/types_map.rs
@@ -666,8 +666,6 @@ pub fn converted_value_to_sea_orm_value(
         }
         #[cfg(feature = "with-time")]
         ConvertedType::TimeDate => {
-            use std::str::FromStr;
-
             let value = sea_orm::entity::prelude::TimeDate::parse(
                 value.string()?,
                 sea_orm::sea_query::value::time_format::FORMAT_DATE,
@@ -683,8 +681,6 @@ pub fn converted_value_to_sea_orm_value(
         }
         #[cfg(feature = "with-time")]
         ConvertedType::TimeTime => {
-            use std::str::FromStr;
-
             let value = sea_orm::entity::prelude::TimeTime::parse(
                 value.string()?,
                 sea_orm::sea_query::value::time_format::FORMAT_TIME,
@@ -700,8 +696,6 @@ pub fn converted_value_to_sea_orm_value(
         }
         #[cfg(feature = "with-time")]
         ConvertedType::TimeDateTime => {
-            use std::str::FromStr;
-
             let value = sea_orm::entity::prelude::TimeDateTime::parse(
                 value.string()?,
                 sea_orm::sea_query::value::time_format::FORMAT_DATETIME,
@@ -717,7 +711,6 @@ pub fn converted_value_to_sea_orm_value(
         }
         #[cfg(feature = "with-time")]
         ConvertedType::TimeDateTimeWithTimeZone => {
-            use std::str::FromStr;
             let value = sea_orm::entity::prelude::TimeDateTimeWithTimeZone::parse(
                 value.string()?,
                 sea_orm::sea_query::value::time_format::FORMAT_DATETIME_TZ,

--- a/src/outputs/entity_object.rs
+++ b/src/outputs/entity_object.rs
@@ -369,6 +369,6 @@ fn sea_query_value_to_graphql_value(
         // #[cfg(feature = "with-mac_address")]
         // #[cfg_attr(docsrs, doc(cfg(feature = "with-mac_address")))]
         // sea_orm::sea_query::Value::MacAddress(value) => value.map(|it| Value::from(it.to_string())),
-        _ => None,
+        // _ => None,
     }
 }

--- a/src/query/entity_object_via_relation.rs
+++ b/src/query/entity_object_via_relation.rs
@@ -152,11 +152,18 @@ impl EntityObjectViaRelationBuilder {
                         // FIXME: optimize union queries
                         // NOTE: each has unique query in order to apply pagination...
 
-                        let Ok(parent) = ctx.parent_value.try_downcast_ref::<T::Model>() else {
-                            return Err(async_graphql::Error::new(format!(
-                                "Failed to downcast object to {}",
-                                entity_object_builder.type_name::<T>()
-                            )));
+                        let parent = match ctx.parent_value.try_downcast_ref::<T::Model>() {
+                            Ok(parent) => parent,
+                            Err(_) => {
+                                match ctx.parent_value.try_downcast_ref::<Option<T::Model>>() {
+                                    Ok(Some(parent)) => parent,
+                                    _ => {
+                                        return Err(async_graphql::Error::new(format!(
+                                            "Failed to downcast object to {object_name}"
+                                        )));
+                                    }
+                                }
+                            }
                         };
 
                         let mut stmt = if <T as Related<R>>::via().is_some() {

--- a/src/utilities.rs
+++ b/src/utilities.rs
@@ -248,9 +248,9 @@ pub fn decode_cursor(s: &str) -> Result<Vec<sea_orm::Value>, sea_orm::DbErr> {
                                 sea_orm::Value::Uuid(None)
                             } else {
                                 sea_orm::Value::Uuid(Some(Box::new(
-                                    data_buffer
-                                        .parse::<sea_orm::prelude::Uuid>()
-                                        .map_err(parse_int_err)?,
+                                    data_buffer.parse::<sea_orm::prelude::Uuid>().map_err(|e| {
+                                        sea_orm::DbErr::Type(format!("Failed to parse UUID: {e}"))
+                                    })?,
                                 )))
                             }
                         }


### PR DESCRIPTION
When accessing a field of an entity, it's possible that the object associated with the parent value may be of type `Option<T>` instead of `T`. Make sure this is handled correctly, at least in the case of `entity_object_via_relation` where `is_owner = true`. I'm not sure if the issue can arise in other cases but it might need fixing there too.
