### PR TITLE
Output conversions: Proper error & None handling

### DIFF
--- a/src/builder_context/types_map.rs
+++ b/src/builder_context/types_map.rs
@@ -8,8 +8,13 @@ use crate::{ActiveEnumBuilder, BuilderContext, EntityObjectBuilder, SeaResult};
 
 pub type FnInputTypeConversion =
     Box<dyn Fn(&ValueAccessor) -> SeaResult<sea_orm::Value> + Send + Sync>;
-pub type FnOutputTypeConversion =
-    Box<dyn Fn(&sea_orm::sea_query::Value) -> SeaResult<async_graphql::Value> + Send + Sync>;
+pub type FnOutputTypeConversion = Box<
+    dyn Fn(
+            &sea_orm::sea_query::Value,
+        ) -> async_graphql::Result<Option<async_graphql::dynamic::FieldValue<'static>>>
+        + Send
+        + Sync,
+>;
 
 /// Used to provide configuration for TypesMapHelper
 pub struct TypesMapConfig {

--- a/src/outputs/entity_object.rs
+++ b/src/outputs/entity_object.rs
@@ -187,13 +187,7 @@ impl EntityObjectBuilder {
 
                     if let Some(conversion_fn) = conversion_fn {
                         let result = conversion_fn(&object.get(column));
-                        return FieldFuture::new(async move {
-                            match result {
-                                Ok(value) => Ok(Some(value)),
-                                // FIXME: proper error reporting
-                                Err(_) => Ok(None),
-                            }
-                        });
+                        return FieldFuture::new(async move { result });
                     }
 
                     FieldFuture::new(async move {


### PR DESCRIPTION
Modify the type signature of `FnOutputTypeConversion` so that instead of returning `Value`, it returns an optional `FieldValue`. This makes it possible to provide conversion functions which return `None` (indicating the value does not exist and should not have its subfields resolved), and also to return other kinds of `FieldValue`s, such as those which own a Rust value (via `FieldVale::owned_any`).

The need for this came from several cases where we have columns stored in the database as json, but in our entity definitions have column types that are custom Rust structs specific to our application, for which we implement the appropriate traits to convert to and from both `serde_json::Value` and `sea_orm::Value`. In some cases these fields are nullable, e.g. we have a column which is of type `Option<AccountConfig>`.

This change allows us to implement the relevant conversion functions so they can return `None` if the account config is null, or `Some(FieldValue::owned_any(config))` if the account config is non-null, after deserializing the `AccountConfig` struct from json.