### PR TITLE
Allow GraphQL types to be specified per column

### DIFF
--- a/src/outputs/entity_object.rs
+++ b/src/outputs/entity_object.rs
@@ -121,12 +121,11 @@ impl EntityObjectBuilder {
                 let column_name = self.column_name::<T>(&column);
 
                 let column_def = column.def();
-                let enum_type_name = column.enum_type_name();
-
-                let graphql_type = match types_map_helper.sea_orm_column_type_to_graphql_type(
-                    column_def.get_column_type(),
+                let graphql_type = match types_map_helper.output_type_for_column::<T>(
+                    &column,
+                    &entity_name,
+                    &column_name,
                     !column_def.is_null(),
-                    enum_type_name,
                 ) {
                     Some(type_name) => type_name,
                     None => return object,

--- a/src/query/entity_query_field.rs
+++ b/src/query/entity_query_field.rs
@@ -101,17 +101,15 @@ impl EntityQueryFieldBuilder {
             .map(|variant| variant.into_column())
             .collect::<Vec<T::Column>>()[0];
 
-        let column_def = column.def();
-        let enum_type_name = column.enum_type_name();
+        let entity_name = entity_object.type_name::<T>();
+        let column_name = entity_object.column_name::<T>(&column);
+
         let types_helper = TypesMapHelper {
             context: self.context,
         };
 
-        let converted_type = types_helper.sea_orm_column_type_to_graphql_type(
-            column_def.get_column_type(),
-            true,
-            enum_type_name,
-        );
+        let converted_type =
+            types_helper.input_type_for_column::<T>(&column, &entity_name, &column_name, true);
 
         let iv = InputValue::new("id", converted_type.expect("primary key to be supported"));
         let context = self.context;


### PR DESCRIPTION
Add extra fields to `TypesMapConfig` to allow a user of the API to specify the input and output types given in the schema for specific columns. When combined with suitable conversion functions, this is particularly useful for providing type safety for columns that are stored in the database as JSON, but which have user-defined Rust types in the entity definition.

Rust types used for these fields need to implement certain traits from SeaORM in order to actually be used, but that is outside the scope of this PR. The present change just allows the types to be given in the schema. This makes it possible (in fact required) to specify subfields in queries, and to obtain type safety when using suitable client libraries.

I have some other changes that (at least in my view) make the API easier to use, but i'll address those in a separate PR as they aren't strictly necessary for obtaining the functionality described above.