### PR TITLE
Don't require TypesMapHelper in ctx.data

### DIFF
--- a/src/query/entity_query_field.rs
+++ b/src/query/entity_query_field.rs
@@ -114,6 +114,7 @@ impl EntityQueryFieldBuilder {
         );
 
         let iv = InputValue::new("id", converted_type.expect("primary key to be supported"));
+        let context = self.context;
 
         Field::new(
             self.type_name::<T>(),
@@ -131,7 +132,7 @@ impl EntityQueryFieldBuilder {
                     }
 
                     let mut stmt = T::find();
-                    let mapper = ctx.data::<crate::TypesMapHelper>()?;
+                    let mapper = TypesMapHelper { context };
                     let column = T::PrimaryKey::iter()
                         .map(|variant| variant.into_column())
                         .collect::<Vec<T::Column>>()[0];


### PR DESCRIPTION
The implementation of singular queries relied on the assumption that a `TypesMapHelper` object would be available in the data associated with an async_graphql context. This isn't actually necessary, because it's possible to create a new `TypesMapHelper` instance given a 'static reference to `BuilderContext,` which is already available to the field implementation.

This change avoids requiring setup code that creates a schema from having to register a `TypesMapHelper` instance with the schema builder. As far as I can tell, this is the only place in seaography where this was an issue.