### PR TITLE
Add options for default + max pagination limit

### DIFF
--- a/examples/sqlite/src/query_root/queries.rs
+++ b/examples/sqlite/src/query_root/queries.rs
@@ -39,7 +39,7 @@ impl Operations {
     ) -> GqlResult<Connection<customer::Entity>> {
         let db = ctx.data::<DatabaseConnection>()?;
         let query = customer::Entity::find().filter(customer::Column::StoreId.eq(2));
-        let connection = apply_pagination(db, query, pagination).await?;
+        let connection = apply_pagination(&CONTEXT, db, query, pagination).await?;
 
         Ok(connection)
     }

--- a/examples/sqlite/tests/query_tests.rs
+++ b/examples/sqlite/tests/query_tests.rs
@@ -153,6 +153,38 @@ async fn test_filter_with_pagination() {
 }
 
 #[tokio::test]
+async fn test_pagination_error() {
+    let schema = get_schema().await;
+
+    let response = schema
+        .execute(
+            r#"
+            {
+              customer(
+                pagination: { page: { page: 2, limit: 0 } }
+              ) {
+                nodes {
+                  customerId
+                }
+                paginationInfo {
+                  pages
+                  current
+                }
+              }
+            }
+            "#,
+        )
+        .await;
+
+    assert_eq!(response.errors.len(), 1);
+
+    assert_eq!(
+        response.errors[0].message,
+        "Query Error: Requested pagination limit must be greater than 0"
+    );
+}
+
+#[tokio::test]
 async fn test_complex_filter_with_pagination() {
     let schema = get_schema().await;
 

--- a/src/inputs/pagination_input.rs
+++ b/src/inputs/pagination_input.rs
@@ -29,13 +29,13 @@ pub struct PaginationInputConfig {
     ///
     /// If both are specified, the lesser of the two will be used as the default. You should set
     /// `default_limit` to be less than or equal to `max_limit`.
-    pub default_limit: Option<u64>, // TODO: tests
+    pub default_limit: Option<u64>,
     /// maximum limit for pagination
     ///
     /// If set, requests including a pagination limit greater than this will be rejected.
     /// If `default_limit` is _not_ set, but `max_limit` _is_, then the latter will effectively
     /// be treated as the default.
-    pub max_limit: Option<u64>, // TODO: tests
+    pub max_limit: Option<u64>,
 }
 
 impl std::default::Default for PaginationInputConfig {

--- a/src/inputs/pagination_input.rs
+++ b/src/inputs/pagination_input.rs
@@ -23,6 +23,19 @@ pub struct PaginationInputConfig {
     pub page: String,
     /// name for 'offset' field
     pub offset: String,
+    /// default limit for pagination
+    ///
+    /// If no default or maximum limit is specified, queries will return *all* matching rows.
+    ///
+    /// If both are specified, the lesser of the two will be used as the default. You should set
+    /// `default_limit` to be less than or equal to `max_limit`.
+    pub default_limit: Option<u64>, // TODO: tests
+    /// maximum limit for pagination
+    ///
+    /// If set, requests including a pagination limit greater than this will be rejected.
+    /// If `default_limit` is _not_ set, but `max_limit` _is_, then the latter will effectively
+    /// be treated as the default.
+    pub max_limit: Option<u64>, // TODO: tests
 }
 
 impl std::default::Default for PaginationInputConfig {
@@ -32,6 +45,8 @@ impl std::default::Default for PaginationInputConfig {
             cursor: "cursor".into(),
             page: "page".into(),
             offset: "offset".into(),
+            default_limit: None,
+            max_limit: None,
         }
     }
 }

--- a/src/query/entity_object_relation.rs
+++ b/src/query/entity_object_relation.rs
@@ -187,7 +187,8 @@ impl EntityObjectRelationBuilder {
                         let pagination =
                             PaginationInputBuilder { context }.parse_object(pagination)?;
 
-                        let connection: Connection<R> = apply_memory_pagination(values, pagination);
+                        let connection: Connection<R> =
+                            apply_memory_pagination(context, values, pagination)?;
 
                         Ok(Some(FieldValue::owned_any(connection)))
                     })

--- a/src/query/entity_object_via_relation.rs
+++ b/src/query/entity_object_via_relation.rs
@@ -204,7 +204,7 @@ impl EntityObjectViaRelationBuilder {
 
                             let stmt = stmt.filter(condition.add(filters));
                             let stmt = apply_order(stmt, order_by);
-                            apply_pagination::<R>(db, stmt, pagination).await?
+                            apply_pagination::<R>(context, db, stmt, pagination).await?
                         } else {
                             let loader = ctx.data_unchecked::<DataLoader<OneToManyLoader<R>>>();
 
@@ -220,7 +220,7 @@ impl EntityObjectViaRelationBuilder {
 
                             let values = loader.load_one(key).await?;
 
-                            apply_memory_pagination(values, pagination)
+                            apply_memory_pagination(context, values, pagination)?
                         };
 
                         Ok(Some(FieldValue::owned_any(connection)))

--- a/src/query/entity_query_field.rs
+++ b/src/query/entity_query_field.rs
@@ -5,7 +5,8 @@ use sea_orm::{DatabaseConnection, EntityTrait, QueryFilter};
 use crate::{
     apply_guard, apply_order, apply_pagination, get_filter_conditions, guard_error,
     pluralize_unique, BuilderContext, ConnectionObjectBuilder, EntityObjectBuilder,
-    FilterInputBuilder, GuardAction, OperationType, OrderInputBuilder, PaginationInputBuilder,
+    FilterInputBuilder, GuardAction, OperationType, OrderInputBuilder, PaginationInput,
+    PaginationInputBuilder,
 };
 
 /// The configuration structure for EntityQueryFieldBuilder
@@ -200,7 +201,8 @@ impl EntityQueryFieldBuilder {
                 let order_by = ctx.args.get(&context.entity_query_field.order_by);
                 let order_by = OrderInputBuilder { context }.parse_object::<T>(order_by)?;
                 let pagination = ctx.args.get(&context.entity_query_field.pagination);
-                let pagination = PaginationInputBuilder { context }.parse_object(pagination)?;
+                let pagination: PaginationInput =
+                    PaginationInputBuilder { context }.parse_object(pagination)?;
 
                 let mut stmt = T::find();
                 if let Some(filter) = hooks.entity_filter(&ctx, &object_name, OperationType::Read) {
@@ -211,7 +213,7 @@ impl EntityQueryFieldBuilder {
 
                 let db = ctx.data::<DatabaseConnection>()?;
 
-                let connection = apply_pagination::<T>(db, stmt, pagination).await?;
+                let connection = apply_pagination::<T>(context, db, stmt, pagination).await?;
 
                 Ok(Some(FieldValue::owned_any(connection)))
             })

--- a/src/query/pagination.rs
+++ b/src/query/pagination.rs
@@ -441,7 +441,6 @@ where
     }
 }
 
-// TODO: tests
 fn apply_pagination_defaults(
     context: &'static BuilderContext,
     pagination: PaginationInput,
@@ -476,7 +475,6 @@ fn apply_pagination_defaults(
     }
 }
 
-// TODO: tests
 fn check_limit(
     context: &'static BuilderContext,
     requested_limit: u64,


### PR DESCRIPTION
Add fields to `PaginationInputConfig` that allow default and maximum limits to be specified, which affect the way in which `PaginatedInput` arguments to queries are handled. Both are optional, and are not set by default.

Specifying the maximum limit can be used to protect against requests that pose undue load on the server due to queries that could otherwise return tens or hundreds of thousands of rows.

Specifying the default limit allows clients to opt-in to pagination, subject to the maximum limit (if specified). If the maximum limit is set but the default is not, the maximum limit will be considered the default in the case where no limit is specified.

If the default or maximum is set, and a client does not specify any pagination options in a query, the 'page' pagination mode will used, with a page number of 0.