### PR TITLE
Tidy up per-column type options

### DIFF
--- a/examples/sqlite/tests/custom_query_tests.rs
+++ b/examples/sqlite/tests/custom_query_tests.rs
@@ -192,6 +192,7 @@ async fn test_custom_query_with_no_pagination() {
         pagination_info: PaginationInfo,
     }
 
+    #[allow(dead_code)]
     #[derive(Deserialize)]
     #[serde(rename_all = "camelCase")]
     struct Customer {

--- a/src/builder_context.rs
+++ b/src/builder_context.rs
@@ -7,6 +7,9 @@ use crate::{
     PaginationInputConfig,
 };
 
+pub mod entity_column_id;
+pub use entity_column_id::*;
+
 pub mod guards;
 pub use guards::*;
 

--- a/src/builder_context/entity_column_id.rs
+++ b/src/builder_context/entity_column_id.rs
@@ -1,0 +1,37 @@
+use sea_orm::{EntityName, EntityTrait, IdenStatic};
+
+use crate::BuilderContext;
+
+#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct EntityColumnId {
+    entity_name: String,
+    column_name: String,
+}
+
+impl EntityColumnId {
+    pub fn of<T>(column: &T::Column) -> EntityColumnId
+    where
+        T: EntityTrait,
+    {
+        EntityColumnId {
+            entity_name: <T as EntityName>::table_name(&T::default()).into(),
+            column_name: column.as_str().into(),
+        }
+    }
+
+    pub fn with_array(&self) -> Self {
+        Self {
+            entity_name: self.entity_name.clone(),
+            column_name: format!("{}.array", self.column_name),
+        }
+    }
+
+    pub fn entity_name(&self, context: &'static BuilderContext) -> String {
+        context.entity_object.type_name.as_ref()(&self.entity_name)
+    }
+
+    pub fn column_name(&self, context: &'static BuilderContext) -> String {
+        let entity_name = self.entity_name(context);
+        context.entity_object.column_name.as_ref()(&entity_name, &self.column_name)
+    }
+}

--- a/src/custom/operation.rs
+++ b/src/custom/operation.rs
@@ -132,7 +132,7 @@ where
         let types_map_helper = TypesMapHelper { context };
         let column_type = T::column_type();
         let column_type =
-            types_map_helper.sea_orm_column_type_to_converted_type("", "", &column_type);
+            types_map_helper.sea_orm_column_type_to_converted_type(None, &column_type);
 
         if value.is_none() {
             // this is Value::unwrap and should not panic

--- a/src/inputs/entity_input.rs
+++ b/src/inputs/entity_input.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeMap;
 use async_graphql::dynamic::{InputObject, InputValue, ObjectAccessor};
 use sea_orm::{ColumnTrait, EntityTrait, Iterable, PrimaryKeyToColumn, PrimaryKeyTrait};
 
-use crate::{BuilderContext, EntityObjectBuilder, SeaResult, TypesMapHelper};
+use crate::{BuilderContext, EntityColumnId, EntityObjectBuilder, SeaResult, TypesMapHelper};
 
 /// The configuration structure of EntityInputBuilder
 pub struct EntityInputConfig {
@@ -78,8 +78,8 @@ impl EntityInputBuilder {
         };
 
         T::Column::iter().fold(InputObject::new(name), |object, column| {
-            let entity_name = entity_object_builder.type_name::<T>();
             let column_name = entity_object_builder.column_name::<T>(&column);
+            let entity_column_id = EntityColumnId::of::<T>(&column);
 
             let full_name = format!("{}.{}", entity_object_builder.type_name::<T>(), column_name);
 
@@ -105,8 +105,7 @@ impl EntityInputBuilder {
 
             let graphql_type = match types_map_helper.input_type_for_column::<T>(
                 &column,
-                &entity_name,
-                &column_name,
+                &entity_column_id,
                 is_insert_not_nullable,
             ) {
                 Some(type_name) => type_name,

--- a/src/query/entity_query_field.rs
+++ b/src/query/entity_query_field.rs
@@ -4,7 +4,7 @@ use sea_orm::{DatabaseConnection, EntityTrait, QueryFilter};
 
 use crate::{
     apply_guard, apply_order, apply_pagination, get_filter_conditions, guard_error,
-    pluralize_unique, BuilderContext, ConnectionObjectBuilder, EntityObjectBuilder,
+    pluralize_unique, BuilderContext, ConnectionObjectBuilder, EntityColumnId, EntityObjectBuilder,
     FilterInputBuilder, GuardAction, OperationType, OrderInputBuilder, PaginationInput,
     PaginationInputBuilder,
 };
@@ -105,15 +105,13 @@ impl EntityQueryFieldBuilder {
             .map(|variant| variant.into_column())
             .collect::<Vec<T::Column>>()[0];
 
-        let entity_name = entity_object.type_name::<T>();
-        let column_name = entity_object.column_name::<T>(&column);
-
         let types_helper = TypesMapHelper {
             context: self.context,
         };
 
+        let entity_column_id = EntityColumnId::of::<T>(&column);
         let converted_type =
-            types_helper.input_type_for_column::<T>(&column, &entity_name, &column_name, true);
+            types_helper.input_type_for_column::<T>(&column, &entity_column_id, true);
 
         let iv = InputValue::new("id", converted_type.expect("primary key to be supported"));
         let context = self.context;


### PR DESCRIPTION
Combine the multiple `BTreeMap` fields of `TypesMapConfig` into one field, `column_options`. Each entry in this map is a `ColumnOptions` object containing the various options that until now were stored in separate `BTreeMap`s.

This makes it easier to set multiple options at once. For example, if you have a specific set of options that you want to apply to multiple columns, you only only need to create a single `ColumnOptions` object and then apply that to several columns. To facilitate this, `ColumnOptions` implements the `Clone` trait, and the conversion function types have been changed from `Box` to `Arc` to allow them to be cloned.

The `ColumnOptions` struct is declared as `#[non_exhaustive]` so that new fields can be added to it in future versions of seaography without breaking backwards compatibility. This attribute prevents creation of instances using the syntax `ColumnOptions { ... }` and instead requires an instance to be constructed with `default()` and then modified. The latter approach will not break with the addition of new fields.

Whether the `column_options` field should belong in `TypesMapConfig` or `BuilderContext` is with considering. Currently I've made it part of the former since it's presently only used for type-related options, but it's possible that other kinds of options might be added in the future, in which case putting it in `BuilderContext` might make more sense.

The `column_options` `BTreeMap` is indexed by keys of the newly-introduced `EntityColumnId` type. This is an opaque identifier for an (entity, column) pair which can only be created by specifying the Entity type and Column value from the SeaORM definitions (see example below). The purpose of using this instead of strings is to enforce a compile-time guarantee that the columns referenced actually exist. This avoids the following problems that can easily occur when referencing the names by strings:

- Misspelt entity or column names

- Capitalization of entity or column names that differs from that produced by the `type_name` and `column_name` functions in `EntityObjectConfig`.

- Renaming of columns in the SeaORM entity definition and forgetting to update the config

Usage example:

```
fn owned_column_options<T>(
    input_type: Option<TypeRef>,
    output_type: Option<TypeRef>,
) -> ColumnOptions
where
    T: for<'de> Deserialize<'de> + Send + Sync + 'static,
{
    let mut options = ColumnOptions::new();
    options.input_conversion = Some(Arc::new(convert_value_from_json));
    options.output_conversion = Some(Arc::new(convert_value_to_owned::<T>));
    options.input_type = input_type;
    options.output_type = output_type;
    options
}

/// ...

context.types.column_options.insert(
    EntityColumnId::of::<accounts::Entity>(&accounts::Column::Config),
    owned_column_options::<AccountConfig>(
        Some(TypeRef::named("AccountConfigInput")),
        Some(TypeRef::named("AccountConfig")),
    ),
);
```