### PR TITLE
Add 'not' operator to filters

### DIFF
--- a/src/inputs/filter_input.rs
+++ b/src/inputs/filter_input.rs
@@ -57,5 +57,6 @@ impl FilterInputBuilder {
         object
             .field(InputValue::new("and", TypeRef::named_nn_list(&filter_name)))
             .field(InputValue::new("or", TypeRef::named_nn_list(&filter_name)))
+            .field(InputValue::new("not", TypeRef::named(&filter_name)))
     }
 }

--- a/src/query/filtering.rs
+++ b/src/query/filtering.rs
@@ -81,5 +81,12 @@ where
         condition
     };
 
+    let condition = if let Some(not) = filters.get("not") {
+        let nested_condition = recursive_prepare_condition::<T>(context, not.object()?)?;
+        condition.add(nested_condition.not())
+    } else {
+        condition
+    };
+
     Ok(condition)
 }


### PR DESCRIPTION
Seaography already supports `and` and `or` operators on filters. This commit adds a `not` operator, which takes a filter object as an argument and maps this onto the corresponding [Condition not()](https://docs.rs/sea-orm/latest/sea_orm/query/struct.Condition.html#method.not) method in SeaORM.

This is particularly useful for using operators that do not have an inverse version, such as array contains. For example, in one use case, we want to select all entities whose tags field does _not_ contain a specific value:

```
{
  runs(filters: {
      not: { tags: { array_contains: ["disabled"] } }
  }) {
    nodes {
      id
      name
      status
    }
  }
}
```