### PR TITLE
fix: opt out of default features in async-graphql

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ features = ["default"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-async-graphql = { version = "7.0", features = ["decimal", "chrono", "dataloader", "dynamic-schema"] }
+async-graphql = { version = "7.0", default-features = false, features = ["decimal", "chrono", "dataloader", "dynamic-schema"] }
 sea-orm = { version = "~2.0.0-rc", default-features = false, features = ["seaography", "with-json"] }
 seaography-macros = { version = "~2.0.0-rc.4", path = "macros", optional = true }
 itertools = { version = "0.12.0" }


### PR DESCRIPTION
## PR Info

Closes #236 

## Bug Fixes

Downstream dependents on seaography could no longer opt out of async-graphql default features

## Breaking Changes

async graphql default features are no longer enabled
