### PR TITLE
Fix Box<Json> compatibility with sea-orm 2.0.0-rc

### DIFF
--- a/macros/src/convert_output.rs
+++ b/macros/src/convert_output.rs
@@ -77,7 +77,7 @@ fn derive_convert_output_enum_containers(
             ) -> async_graphql::Result<Option<async_graphql::dynamic::FieldValue<'static>>> {
                 if let sea_orm::sea_query::value::Value::Json(opt_json) = value {
                     if let Some(json) = opt_json {
-                        match serde_json::from_value::<#orig_ident>(json.clone()) {
+                        match serde_json::from_value::<#orig_ident>((*json).clone()) {
                             Ok(obj) => match obj {
                                 #(#variant_matches)*
                             },

--- a/src/builder_context/types_map.rs
+++ b/src/builder_context/types_map.rs
@@ -660,7 +660,7 @@ pub fn converted_value_to_sea_orm_value(
                 })?,
                 Err(_) => value.deserialize()?,
             };
-            sea_orm::Value::Json(Some(value))
+            sea_orm::Value::Json(Some(Box::new(value)))
         }
         #[cfg(feature = "with-chrono")]
         ConvertedType::ChronoDate => {

--- a/src/outputs/entity_object.rs
+++ b/src/outputs/entity_object.rs
@@ -282,7 +282,7 @@ pub(crate) fn sea_query_value_to_graphql_value(
         #[cfg(feature = "with-json")]
         #[cfg_attr(docsrs, doc(cfg(feature = "with-json")))]
         sea_orm::sea_query::Value::Json(value) => {
-            value.map(|it| match Value::from_json(it.clone()) {
+            value.map(|it| match Value::from_json((*it).clone()) {
                 Ok(v) => v,
                 Err(_) => Value::from(it.to_string()),
             })


### PR DESCRIPTION
Handle upstream sea-query change where Value::Json now uses Box<serde_json::Value> instead of serde_json::Value directly.

  PR Info

  - Closes
  - Dependencies:
    - Requires sea-orm 2.0.0-rc or later
  - Dependents:

  New Features

  - N/A

  Bug Fixes

  - Fix compatibility with sea-orm 2.0.0-rc where sea_query::Value::Json now wraps the JSON value in a Box. Updated all locations that construct or destructure Value::Json to properly box/unbox the value.

  Breaking Changes

  - Requires sea-orm 2.0.0-rc or later due to the upstream Value::Json(Box<...>) change

  Changes

  - macros/src/convert_output.rs: Dereference boxed json before cloning ((*json).clone())
  - src/builder_context/types_map.rs: Wrap json value in Box::new() when constructing Value::Json
  - src/outputs/entity_object.rs: Dereference boxed json before cloning ((*it).clone())